### PR TITLE
Add exact phrase mode to nonprofit search

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,127 +1,332 @@
 # Giving Tuesday Datamart
 
-VDL's internal data backbone for IRS 990 / 990-PF filings. Pulls the Giving
-Tuesday Datamart CSVs from S3, ingests them into PostgreSQL with full lineage
-tracking, and feeds downstream analyses and the React explorer in `frontend/`.
+A data backbone for IRS Form 990 / 990-PF filings. It pulls Giving Tuesday's
+public Datamart CSVs from S3, lands them in PostgreSQL with full lineage,
+materializes canonical entity tables and a Postgres full-text-search surface
+on top, runs grant-recipient matching, and exposes a read-only Python
+client. A Next.js explorer (`peerlo`) sits in [`frontend/`](frontend/).
 
-## Overview
+```
+S3 (Giving Tuesday public bucket)
+        │
+        ▼
+   Staging tables          ── public.basic_fields, public.mission_statements, ...
+   (all-TEXT, lineage-stamped)
+        │
+        ▼
+   Canonical tables        ── public.nonprofit_canonical, public.nonprofit_text (FTS), ...
+   (typed, one row per real entity)
+        │
+        ▼
+   Matched grants          ── public.unioned_grants
+   (private-grants ↔ recipient EIN, plus Schedule I)
+        │
+        ▼
+   GtDatamartClient        ── read-only Python client, used by the frontend
+                              and by any downstream consumer
+```
 
-- **Source**: `gt990datalake-analytics-and-datamarts` S3 bucket (public-read;
-  no credentials needed).
-- **Target**: `gt_datamart` database on the shared VDL RDS host. Dedicated
-  database (not shared with the rest of the VDL Postgres) so a bad refresh
-  can't damage unrelated data, and so we can drop/recreate cheaply during
-  early-phase work.
-- **Schemas in `gt_datamart`**:
-  - `public.*` — all 9 staging tables (`basic_fields`, `mission_statements`,
-    `programs`, `schedule_o`, `grants_to_domestic_organizations`,
-    `privategrants`, `basic_fields_pf`, `officers`, `officers_pf`).
-  - `datamart_meta.ingest_runs` — one row per ingest, records what was
-    pulled, when, and how it went.
-- **Every staging row** gets 4 lineage columns stamped at COPY time:
-  `_source_version`, `_source_url`, `_ingested_at`, `_ingest_run_id`.
-- **Every staging column is `TEXT`**. Zero-padded EINs (`012345678`), ZIPs
-  (`01234`), and phones round-trip intact. Consumers cast at query time
-  (`SUM(totrevcuryea::bigint)`).
+## What's in `gt_datamart`
+
+A dedicated Postgres database, broken into four layers:
+
+- **Staging** (`public.*`) — direct ingest of the Giving Tuesday CSVs. One
+  table per source (e.g. `basic_fields`, `mission_statements`, `programs`,
+  `schedule_o`, `grants_to_domestic_organizations`, `privategrants`,
+  `basic_fields_pf`). Every column is `TEXT` so zero-padded EINs
+  (`012345678`), ZIPs (`01234`), and phones round-trip intact; cast at
+  query time (`SUM(totrevcuryea::bigint)`). Every row carries four lineage
+  columns: `_source_version`, `_source_url`, `_ingested_at`,
+  `_ingest_run_id`.
+- **Canonical** (`public.*`) — typed materializations rebuilt from
+  staging. One row per real entity (`nonprofit_canonical`,
+  `funder_canonical`, optionally `person_canonical`); a deduped text
+  bundle with a `tsvector` GIN index for full-text search
+  (`nonprofit_text`); a filtered Schedule O Part III narrative table
+  (`schedule_o_part_iii`).
+- **Matched grants** — `unioned_grants` is the consumer-facing grants
+  table: 990-PF grants joined to their matched recipient EINs (via
+  `recordlinkage`) UNION'd with Schedule I grants. Indexed on both
+  granter and grantee EIN.
+- **Lineage** (`datamart_meta.*`) — `ingest_runs` records every staging
+  ingest; `canonical_builds` records every canonical rebuild together
+  with the `ingest_run_id` of every staging input it read.
 
 ## Setup
 
-### 1. Python environment
+### 1. Install
 
-Use the `givingtuesday` pyenv (has the required deps — `polars` and friends):
+The package is pip-installable. Two profiles:
 
 ```bash
-GT_PY=~/.pyenv/versions/3.12.11/envs/givingtuesday/bin/python
+# Read-only client only — for downstream consumers (notebooks, app
+# backends). Dependency-light: just sqlalchemy + psycopg2-binary.
+pip install -e .
+
+# Full pipeline — ingestion, canonical build, grant matching.
+# Pulls boto3, polars, recordlinkage, pyarrow, etc.
+pip install -e '.[ingest]'
 ```
 
-### 2. VDL config
+Requires Python ≥ 3.10.
 
-Standard VDL `config.ini` with a `[postgres]` section pointing at the RDS
-host. See `vdl-tools` setup if you don't already have one.
+### 2. Postgres
 
-### 3. Create the `gt_datamart` database (one-time)
-
-The ingestion path deliberately does **not** create databases. Before the
-first refresh:
+You need an empty Postgres database called `gt_datamart`. The pipeline
+deliberately does not create databases for you — having a human do this
+once means a typo in config can never silently provision a new database.
 
 ```bash
-psql -h <rds-host> -U <vdl-user> -d postgres -c "CREATE DATABASE gt_datamart;"
+createdb gt_datamart
+# or:
+psql -h <host> -U <user> -d postgres -c "CREATE DATABASE gt_datamart;"
 ```
 
-(Or `createdb gt_datamart` if your libpq env is set.)
+Configure connection details in either:
 
-## Commands
+- A `config.ini` file with a `[postgres]` section pointing at your host
+  — read by [`vdl-tools`](https://github.com/vibrant-data-labs/vdl-tools)
+  (a separate library, pulled in as a dependency of the `[ingest]`
+  install profile).
+- Or the `GT_DATAMART_PG_*` environment variables, used by the
+  read-only client. See [Read-only Python client](#read-only-python-client).
 
-All via the sources CLI:
+The ingest path uses `config.ini`; the read-only client uses the
+environment variables. They are independent — set whichever you need.
+
+### 3. Source data
+
+Source CSVs live in the public-read S3 bucket
+`gt990datalake-analytics-and-datamarts` (no AWS credentials required).
+The pipeline lists the bucket and picks the newest matching file for
+each registered source automatically.
+
+## Usage
+
+All commands run as Python modules. Output is plain text tables, easy to
+pipe or eyeball.
+
+### Inspect
 
 ```bash
-# What's currently in S3 vs. what we know about?
-$GT_PY -m givingtuesday_datamart.sources status
+# What's in S3 right now? (no DB connection)
+python -m givingtuesday_datamart.sources status
+
+# What's loaded into gt_datamart, at what version, how long ago?
+python -m givingtuesday_datamart.sources loaded
 ```
 
-Prints a table: logical name, target staging table, latest S3 version date,
-filename, size. Fast (S3 list only, no DB, no downloads).
+`status` lists each registered source alongside the newest matching file
+in S3 — version date, filename, size. `loaded` queries the run-history
+table and shows the latest run per source: status (`success` / `failed` /
+`skipped` / `never`), version, row count, last-ingested-at, age, and a
+count of validation warnings. Failed runs and validation warnings are
+re-printed below the table so they don't disappear into JSONB.
+
+### Refresh staging
 
 ```bash
-# What tables have been loaded into gt_datamart, at what version, how long ago?
-$GT_PY -m givingtuesday_datamart.sources loaded
-```
+# Refresh every default source. Skips a successful (source, version)
+# pair — it's already loaded — and reports it as `skipped`.
+python -m givingtuesday_datamart.sources refresh
 
-Queries `datamart_meta.ingest_runs` and shows the latest run per source:
-status (`success` / `failed` / `skipped` / `never`), version, row count,
-when it finished, and age. Failed runs are re-surfaced as warnings below
-the table. Hits the DB only, no S3.
+# A single source.
+python -m givingtuesday_datamart.sources refresh --source irs_990_missions
 
-```bash
-# Ingest everything (~32 GB of CSV total; run overnight)
-$GT_PY -m givingtuesday_datamart.sources refresh
-
-# Single source
-$GT_PY -m givingtuesday_datamart.sources refresh --source irs_990_missions
-
-# Multiple sources in one command
-$GT_PY -m givingtuesday_datamart.sources refresh \
+# Multiple specific sources.
+python -m givingtuesday_datamart.sources refresh \
     --source irs_990_basic_fields \
     --source irs_990_missions
 
-# Force re-ingest (bypass idempotency; drops + recreates the staging table)
-$GT_PY -m givingtuesday_datamart.sources refresh --source irs_990_missions --force
+# Bypass the (source, version) idempotency check — drops and recreates
+# the staging table from scratch.
+python -m givingtuesday_datamart.sources refresh --source irs_990_missions --force
 ```
 
-### Idempotency
+Refresh streams CSVs straight from S3 to Postgres `COPY`, in batches of
+50,000 rows, stamping the four lineage columns inline. Every successful
+ingest runs a small validation pass (see
+[Validation](#validation)). A failed run is recorded and does not block
+retries — just rerun the same command.
 
-`refresh` is idempotent on `(logical_name, source_version)`. If a successful
-run already exists in `datamart_meta.ingest_runs` for the same source +
-version, the refresh is skipped with status `skipped`. Use `--force` to
-override (drops the staging table and reingests).
-
-A `failed` run does **not** block a retry — rerun the same command and it
-will try again.
-
-### Recommended first-run order
-
-Smallest to largest, so errors surface fast:
+### Build canonical tables
 
 ```bash
-$GT_PY -m givingtuesday_datamart.sources refresh --source irs_990pf_basic_fields   # ~730 MB
-$GT_PY -m givingtuesday_datamart.sources refresh --source irs_990pf_officers       # ~1.0 GB
-$GT_PY -m givingtuesday_datamart.sources refresh --source irs_990_missions         # ~1.0 GB
-$GT_PY -m givingtuesday_datamart.sources refresh --source irs_schedule_i_grants    # ~1.9 GB
-$GT_PY -m givingtuesday_datamart.sources refresh --source irs_990_basic_fields     # ~2.1 GB
-$GT_PY -m givingtuesday_datamart.sources refresh --source irs_990_programs         # ~2.2 GB
-$GT_PY -m givingtuesday_datamart.sources refresh --source irs_990pf_grants         # ~4.4 GB
-$GT_PY -m givingtuesday_datamart.sources refresh --source irs_990_officers         # ~8.6 GB
-$GT_PY -m givingtuesday_datamart.sources refresh --source irs_schedule_o           # ~10  GB
+# Rebuild the canonical layer from current staging.
+# DROP + CREATE inside a transaction; idempotent.
+python -m givingtuesday_datamart.sources build-canonical
 ```
+
+Run this after a successful `refresh`. It rebuilds:
+
+- `public.nonprofit_canonical` — one row per EIN. Identity fields
+  (name, DBAs, address) and the latest filing's identifiers, picked via
+  `DISTINCT ON (filerein)` ordered by tax year desc, tax-period-end
+  desc, ingested_at desc as deterministic tiebreaks.
+- `public.nonprofit_text` — one row per EIN with a deduped concatenation
+  of every non-empty text field across every year (mission statement,
+  Part III program activities 1/2/3, Schedule O Part III narrative). A
+  `text_tsv` column carries a `tsvector` with a GIN index for FTS.
+- `public.funder_canonical` — analogous to `nonprofit_canonical` but
+  built from the 990-PF universe.
+- `public.schedule_o_part_iii` — Schedule O rows filtered to Form
+  990 / 990-EZ Part III continuation narratives only, via
+  case-insensitive word-boundary regex on `sidfalrdesc`.
+
+The build records itself in `datamart_meta.canonical_builds` together
+with the `ingest_run_id` of every staging input — so a downstream
+consumer can always answer "which source versions is this canonical
+table derived from?".
+
+### Officers tables (opt-in)
+
+Two staging tables — `irs_990_officers` and `irs_990pf_officers` — are
+flagged `skip_default_refresh=True` because the underlying CSVs are
+large (~18 GB hot for the 990 side). They are not part of the default
+`refresh` and the canonical layer that depends on them
+(`person_canonical`, `org_person_role`) is built only when explicitly
+requested:
+
+```bash
+# Explicit ingest:
+python -m givingtuesday_datamart.sources refresh --source irs_990_officers
+python -m givingtuesday_datamart.sources refresh --source irs_990pf_officers
+
+# Then build the people canonical tables:
+python -m givingtuesday_datamart.sources build-canonical --with-people
+```
+
+To make officers part of the default refresh, flip
+`skip_default_refresh=False` for those entries in
+[`registry.py`](givingtuesday_datamart/sources/registry.py).
+
+### Match grants
+
+```bash
+# Match private-foundation grants to recipient EINs and rebuild
+# public.unioned_grants. Resumable from S3-stored chunk checkpoints.
+python -m givingtuesday_datamart.grant_matching
+
+# Test mode: cap input row counts; chunks are written to a quarantined
+# subdirectory so they can't be confused with production checkpoints.
+python -m givingtuesday_datamart.grant_matching --limit 10000
+
+# Recompute from scratch, ignoring any existing chunks.
+python -m givingtuesday_datamart.grant_matching --no-resume
+
+# Tune chunk size or resume parallelism.
+python -m givingtuesday_datamart.grant_matching --chunk-size 50000 --resume-workers 32
+```
+
+Uses [`recordlinkage`](https://recordlinkage.readthedocs.io/) to compare
+private-grant recipient names + addresses against `nonprofit_canonical`.
+Candidate-pair chunks are written to S3 keyed on the source-data lineage
+(`(privategrants version, nonprofit_canonical version)`), so reruns
+against the same inputs resume from existing chunks.
+
+### Recommended first run
+
+Refresh smallest-to-largest so that errors surface fast:
+
+```bash
+python -m givingtuesday_datamart.sources refresh --source irs_990pf_basic_fields  # ~730 MB
+python -m givingtuesday_datamart.sources refresh --source irs_990_missions        # ~1.0 GB
+python -m givingtuesday_datamart.sources refresh --source irs_schedule_i_grants   # ~1.9 GB
+python -m givingtuesday_datamart.sources refresh --source irs_990_basic_fields    # ~2.1 GB
+python -m givingtuesday_datamart.sources refresh --source irs_990_programs        # ~2.2 GB
+python -m givingtuesday_datamart.sources refresh --source irs_990pf_grants        # ~4.4 GB
+python -m givingtuesday_datamart.sources refresh --source irs_schedule_o          # ~10  GB
+
+python -m givingtuesday_datamart.sources build-canonical
+python -m givingtuesday_datamart.grant_matching
+```
+
+End-to-end this is a multi-hour job; plan for an overnight run.
+
+## Validation
+
+Every successful staging refresh runs a validation pass before the run is
+finalized ([`validation.py`](givingtuesday_datamart/validation.py)):
+
+- **Hard-fail** — the run is marked `failed` and rolled back if: the row
+  count is zero; lineage columns are missing on any row; or any required
+  column has more than 1% NULL.
+- **Soft-warn** — the run stays `success`, but warnings are recorded in
+  the `validation` JSONB column when: the schema drifts from the prior
+  successful run; or row count falls outside [0.8×, 2.0×] of the prior
+  successful run.
+
+Warnings show up in the `loaded` command's `warns` column and are
+printed below the table.
+
+## Read-only Python client
+
+`GtDatamartClient` is a SQLAlchemy-based read-only client over the
+canonical surface. It has no dependency on the heavier `[ingest]` extra
+— `pip install -e .` is enough — so downstream consumers don't need to
+pull in `boto3`, `polars`, etc. just to query the database.
+
+```python
+from givingtuesday_datamart.client import GtDatamartClient
+
+# Connection precedence:
+#   1. engine=...         (pre-built SQLAlchemy Engine)
+#   2. url="postgresql://..."
+#   3. host/port/user/password/database kwargs
+#   4. GT_DATAMART_PG_HOST / _PORT / _USER / _PASSWORD / _DATABASE env vars
+#      (port and database have sensible defaults)
+client = GtDatamartClient()
+
+hits = client.search_nonprofits(["climate", "wildfire"], limit=20)
+profile = client.get_nonprofit(ein="123456789")
+years = client.get_basic_fields(eins=["123456789"], min_taxyear=2018)
+grants_received = client.get_grants(eins=["123456789"], role="grantee")
+grants_made = client.get_grants(eins=["123456789"], role="granter")
+```
+
+The methods return frozen dataclasses (`NonprofitHit`, `Nonprofit`,
+`BasicFieldsRow`, `Grant`); the client deliberately does not depend on
+pandas. Callers that want a DataFrame:
+
+```python
+from dataclasses import asdict
+import pandas as pd
+df = pd.DataFrame.from_records([asdict(h) for h in hits])
+```
+
+## Frontend (`peerlo`)
+
+A Next.js explorer that reads `gt_datamart` directly via its own pg pool
+([`frontend/src/lib/db.ts`](frontend/src/lib/db.ts)).
+
+- **Search** — Postgres FTS over `nonprofit_text.text_tsv`, with a mode
+  toggle (search by name, by narrative, or both).
+- **Org profile** — canonical identity, narrative, lineage, multi-year
+  basic fields, and server-side paginated grants tables on both sides
+  (received and made).
+- **`/about`** — explainer page.
+
+Local development:
+
+```bash
+cd frontend
+cp .env.local.example .env.local   # then fill in PG_HOST / PG_USER / PG_PASSWORD
+npm install
+npm run dev
+```
+
+The frontend reads `PG_HOST` / `PG_PORT` / `PG_DATABASE` / `PG_USER` /
+`PG_PASSWORD` from `.env.local`.
 
 ## Verifying a refresh
 
-Connect to `gt_datamart` and check the run table and the lineage columns:
+Connect to `gt_datamart` to inspect the lineage and validation tables
+directly:
 
 ```sql
--- All runs, newest first
+-- All ingest runs, newest first, with validation JSONB
 SELECT run_id, logical_name, source_version, status, row_count,
-       finished_at - started_at AS duration, error
+       finished_at - started_at AS duration, error, validation
 FROM datamart_meta.ingest_runs
 ORDER BY started_at DESC;
 
@@ -131,17 +336,20 @@ SELECT DISTINCT ON (logical_name)
 FROM datamart_meta.ingest_runs
 ORDER BY logical_name, finished_at DESC;
 
--- Lineage stamped on every row (exactly one version per staging table)
+-- Lineage stamped on every row of a staging table
 SELECT DISTINCT _source_version, _ingest_run_id
 FROM public.mission_statements;
 
--- Row count parity with ingest_runs
-SELECT COUNT(*) FROM public.mission_statements;
+-- Canonical build lineage: which staging runs fed the latest rebuild?
+SELECT build_id, started_at, finished_at, source_runs
+FROM datamart_meta.canonical_builds
+ORDER BY started_at DESC LIMIT 5;
 ```
 
 ## Adding a new source
 
-Edit [`givingtuesday_datamart/sources/registry.py`](givingtuesday_datamart/sources/registry.py)
+Edit
+[`givingtuesday_datamart/sources/registry.py`](givingtuesday_datamart/sources/registry.py)
 and append a new `_spec(...)` entry:
 
 ```python
@@ -149,90 +357,120 @@ _spec(
     logical_name="irs_new_thing",
     staging_table_name="public.new_thing",
     form_type="990",  # or "990-PF"
-    description="Short human-readable description of what this table is.",
+    description="Short human-readable description.",
     filename_regex=r"^(\d{4}_\d{2}_\d{2})_All_Years_NewThingPattern\.csv$",
+    required_columns=("filerein",),
+    indexes=(IndexSpec("ix_new_thing_filerein", ("filerein",)),),
 ),
 ```
 
-The **first capture group** of `filename_regex` must capture `YYYY_MM_DD` so
-the resolver can pick the newest matching file.
+Two non-obvious requirements:
 
-Verify with `status` before running `refresh`:
+1. The **first capture group** of `filename_regex` must capture
+   `YYYY_MM_DD` so the resolver can pick the newest matching file.
+2. `required_columns` are checked by validation; `indexes` are recreated
+   by ingestion after every COPY (so they can never drift from
+   declaration).
+
+Verify before running `refresh`:
 
 ```bash
-$GT_PY -m givingtuesday_datamart.sources status
+python -m givingtuesday_datamart.sources status
 ```
 
-If the new source shows `NOT FOUND`, the regex doesn't match anything in the
-bucket — fix it before running `refresh`.
+If the new source shows `NOT FOUND`, the regex doesn't match anything in
+the bucket — fix it before running `refresh`. Source-CSV filenames are
+slightly inconsistent (e.g. `990PFPart7p1Officers.csv` vs
+`990PFPart7p1-Officers.csv`); make patterns tolerant (`-?`, character
+classes) rather than exact.
 
 ## Design notes
 
-- **All-TEXT staging.** Every column created by `_create_table_from_columns`
-  is `TEXT`. Zero-padded EINs, ZIPs, and phones round-trip intact. Consumers
-  cast at query time (`::bigint`, `::double precision`, etc.). Typed
-  canonical views are a Phase 2 concern.
-- **Streaming ingestion.** No disk cache, no pandas in the hot path. CSV is
-  parsed via `csv.reader` over an `io.TextIOWrapper(newline="")` on top of a
-  `BufferedReader` wrapping `response.iter_content()`. Quoted multi-line
-  fields (mission statements, Schedule O narratives) are preserved — a
-  naive `iter_lines` split would mangle them.
-- **COPY in batches of 50,000.** Each batch is stamped with the 4 lineage
-  columns in the same COPY command — no second pass.
-- **Idempotency is enforced in the app layer**, not via DB constraints.
+- **All-TEXT staging.** Every staging column is `TEXT`. Zero-padded
+  identifiers round-trip intact. Consumers cast at query time, or read
+  typed columns from the canonical / unioned tables.
+- **Streaming ingestion.** No on-disk cache, no pandas in the hot path.
+  CSV is parsed via `csv.reader` over an `io.TextIOWrapper(newline="")`
+  on a `BufferedReader` wrapping `response.iter_content()`. Quoted
+  multi-line fields (mission statements, Schedule O narratives) are
+  preserved — a naive `iter_lines` split would mangle them.
+- **`COPY` in batches of 50,000.** Each batch is stamped with the four
+  lineage columns inside the same `COPY` command — no second pass.
+- **Indexes are declarative.** `SourceSpec.indexes` is the single source
+  of truth; ingestion recreates indexes from the spec after every COPY.
+- **Idempotency in the application layer**, not via DB constraints.
   Before creating a run row, we check `datamart_meta.ingest_runs` for an
-  existing successful `(logical_name, source_version)`. Simple and easy to
-  reason about; future work could add a unique constraint if needed.
-- **Database isolation.** `gt_datamart` is a separate database on the same
-  RDS host as the main VDL DB. Threaded via `get_session(config=datamart_config())`
-  rather than a parallel connection module.
+  existing successful `(logical_name, source_version)`. Easy to reason
+  about; easy to override with `--force`.
+- **Database isolation.** `gt_datamart` is its own database, separate
+  from any other Postgres database that might exist on the same host.
+  A bad refresh can never damage unrelated data.
 
 ## Troubleshooting
 
-**"Skipping" when you want to re-ingest.** That's idempotency working. Pass
-`--force` to drop the staging table and re-run.
+**A `refresh` is reporting `skipped` and you want to actually re-ingest.**
+Idempotency working as designed. Pass `--force` to drop the staging
+table and re-run.
 
-**"database 'gt_datamart' does not exist".** Do the one-time `createdb
-gt_datamart` step above.
+**`database "gt_datamart" does not exist`.** Run the one-time
+`createdb gt_datamart` step in [Setup](#2-postgres).
 
-**"No module named 'polars'" (or pandas, psycopg2, etc.).** You're not in the
-`givingtuesday` pyenv — `vdl-tools-312` is missing polars. Use
-`~/.pyenv/versions/3.12.11/envs/givingtuesday/bin/python`.
+**A source shows `NOT FOUND` in `status`.** The `filename_regex` in
+`registry.py` doesn't match anything in the bucket. Check what's
+actually there with `aws s3 ls
+s3://gt990datalake-analytics-and-datamarts/EfileDataMarts/ --no-sign-request`,
+then loosen the regex (`-?`, `[A-Z_]?`) rather than hard-coding the new
+filename.
 
-**"NOT FOUND" for a source in `status`.** Giving Tuesday occasionally
-renames files (e.g., `990PFPart7p1Officers.csv` vs `990PFPart7p1-Officers.csv`).
-The `filename_regex` in the registry needs an update; make the pattern
-tolerant (`-?`, character classes) rather than exact.
+**A validation warning showed up in `loaded`.** Inspect the JSONB:
 
-**Staging columns showing up as `bigint` / `double precision`.** You're
-looking at a table that was ingested by the deleted standard (pandas
-`to_sql`) path, before we switched to streaming-only. `--force` re-ingest
-and it'll come out as all-`TEXT`.
+```sql
+SELECT validation
+FROM datamart_meta.ingest_runs
+WHERE run_id = '<run_id from loaded output>';
+```
+
+The blob lists every check, its status, and a free-form `detail` field.
+
+**`build-canonical` fails complaining about a missing staging table.**
+The canonical layer reads from staging; if a source it depends on is
+empty (e.g. `programs`, `mission_statements`, `schedule_o`), refresh
+that source first.
+
+**`GtDatamartClient` raises "missing connection components".** Either
+pass `host` / `user` / `password` to the constructor, or set
+`GT_DATAMART_PG_HOST`, `GT_DATAMART_PG_USER`, and `GT_DATAMART_PG_PASSWORD`
+in the environment.
 
 ## Repo layout
 
 ```
 givingtuesday_datamart/
   sources/
-    spec.py          # SourceSpec / ColumnSpec / IndexSpec dataclasses
-    registry.py      # One SourceSpec per ingested table
-    resolver.py      # Picks the latest matching file from S3 (boto3 unsigned)
-    __main__.py      # CLI: status, refresh
-  ingestion.py       # ingest_source() + ingest_latest(), ingest_runs tracking
-  write_data_to_sql.py  # Streaming CSV -> COPY (all-TEXT columns, lineage stamping)
-  sql_queries/       # Downstream analytical SQL (build canonical views, grants unions, etc.)
-  grant_matching.py  # recordlinkage pipeline: PF grants → recipient EINs, rebuilds public.unioned_grants
-scripts/
-  create_tables.py   # Thin wrapper around `sources refresh`
-frontend/            # Next.js app (reads from the old VDL DB today; migration to gt_datamart TBD)
+    spec.py             # SourceSpec / ColumnSpec / IndexSpec dataclasses
+    registry.py         # One SourceSpec per ingested table
+    resolver.py         # Picks the latest matching file from S3 (boto3 unsigned)
+    __main__.py         # CLI: status, loaded, refresh, build-canonical
+  ingestion.py          # ingest_source(); ingest_runs tracking; index rebuild
+  write_data_to_sql.py  # Streaming CSV -> COPY (all-TEXT cols, lineage stamping)
+  validation.py         # Hard-fail + soft-warn checks run after each refresh
+  canonical/
+    build.py            # Canonical layer: nonprofit_canonical, nonprofit_text (FTS),
+                        # funder_canonical, schedule_o_part_iii, optional people
+  client/
+    client.py           # GtDatamartClient — read-only, no extra dependencies
+    models.py           # Frozen dataclasses returned by the client
+  grant_matching.py     # recordlinkage pipeline + S3-checkpointed resume;
+                        # rebuilds public.unioned_grants
+frontend/               # Next.js peerlo app (reads gt_datamart via pg pool)
 docs/
-  backbone-plan.md   # Phased plan for the full data backbone (ingestion, query surfaces, matching)
+  backbone-plan.md      # Detailed architecture + decision history
+pyproject.toml          # pip-installable; [ingest] extra for the heavy path
 ```
 
-## The full plan
+## More
 
-[`docs/backbone-plan.md`](docs/backbone-plan.md) has the phased roadmap for
-this work — all three phases (ingestion + lineage; query surfaces and
-canonical entity views; matching, classification, and person dedup), the
-architecture decisions behind them, critical files, and verification
-criteria per phase. Read it before starting anything non-trivial.
+[`docs/backbone-plan.md`](docs/backbone-plan.md) is a deeper architecture
+document — the phased roadmap, the trade-offs behind each layer, and
+verification criteria. Useful when extending the pipeline beyond what's
+covered here.

--- a/README.md
+++ b/README.md
@@ -278,6 +278,11 @@ from givingtuesday_datamart.client import GtDatamartClient
 client = GtDatamartClient()
 
 hits = client.search_nonprofits(["climate", "wildfire"], limit=20)
+phrase_hits = client.search_nonprofits(
+    ["food bank", "animal shelter"],
+    search_mode="exact",  # or "stemmed" for English FTS phrase matching
+    limit=20,
+)
 profile = client.get_nonprofit(ein="123456789")
 years = client.get_basic_fields(eins=["123456789"], min_taxyear=2018)
 grants_received = client.get_grants(eins=["123456789"], role="grantee")

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -135,7 +135,7 @@ function SearchInstructions() {
       <summary className="cursor-pointer list-none px-4 py-2.5 flex items-center justify-between gap-2 hover:text-foreground/80 transition-colors">
         <span>
           <span className="font-semibold text-foreground/80">Search syntax & tips</span>
-          <span className="text-muted-foreground/70"> — match modes, boolean operators, exact phrases</span>
+          <span className="text-muted-foreground/70"> — match modes, supported operators, what doesn&rsquo;t work</span>
         </span>
         <span className="text-muted-foreground/60 transition-transform group-open:rotate-90" aria-hidden>
           ›
@@ -163,7 +163,7 @@ function SearchInstructions() {
 
       <div className="space-y-1.5 pt-2 border-t border-border/40">
         <p>
-          <span className="font-semibold text-foreground/80">Boolean syntax</span> (applies to narrative matching — the name path is a plain substring search):
+          <span className="font-semibold text-foreground/80">Search syntax</span> (applies to narrative matching — the name path is a plain substring search):
         </p>
         <ul className="list-disc pl-5 space-y-0.5">
           <li>
@@ -185,11 +185,26 @@ function SearchInstructions() {
             <code className="font-mono bg-secondary/60 px-1 py-0.5 rounded">&quot;food security&quot;</code>{' '}
             requires the words adjacent and in order.
           </li>
-          <li>
-            Combine freely —{' '}
-            <code className="font-mono bg-secondary/60 px-1 py-0.5 rounded">&quot;food security&quot; OR hunger -emergency</code>.
-          </li>
         </ul>
+
+        <p className="text-foreground/80 pt-2">
+          <span className="font-semibold">This isn&rsquo;t full Boolean search.</span>{' '}
+          Parentheses are ignored, the literal word <code className="font-mono">AND</code> is ignored,
+          and the symbols <code className="font-mono">&amp;</code> <code className="font-mono">|</code> <code className="font-mono">!</code> aren&rsquo;t operators here —
+          only <code className="font-mono">OR</code>, <code className="font-mono">-</code>, and <code className="font-mono">&quot;…&quot;</code> are.
+          <code className="font-mono"> OR</code> also binds looser than the implicit AND, so{' '}
+          <code className="font-mono bg-secondary/60 px-1 py-0.5 rounded">solar OR wind clean</code>{' '}
+          means <code className="font-mono">solar</code> OR (<code className="font-mono">wind</code> AND <code className="font-mono">clean</code>).
+        </p>
+
+        <p className="text-foreground/80">
+          <span className="font-semibold">To group an OR with an AND,</span> distribute it yourself —{' '}
+          <code className="font-mono bg-secondary/60 px-1 py-0.5 rounded">(climate OR environment) AND asthma</code>{' '}
+          doesn&rsquo;t work, but{' '}
+          <code className="font-mono bg-secondary/60 px-1 py-0.5 rounded">climate asthma OR environment asthma</code>{' '}
+          does.
+        </p>
+
         <p className="text-muted-foreground/70 italic pt-1">
           Stemming means <code className="font-mono">renewable</code> matches <code className="font-mono">renewables</code> and <code className="font-mono">renewing</code>; common stop-words (the, of, and) are ignored.
         </p>

--- a/givingtuesday_datamart/canonical/build.py
+++ b/givingtuesday_datamart/canonical/build.py
@@ -287,47 +287,50 @@ def _build_nonprofit_canonical(session) -> int:
 def _build_nonprofit_text(session) -> int:
     """DROP + CREATE + populate public.nonprofit_text with a GIN-indexed tsvector.
 
-    The UNION across every (ein, source, text) triple provides field-level
-    dedup: identical text across years or across activity slots collapses
-    to one row, so the string_agg result contains each distinct non-empty
-    snippet exactly once per EIN.
+    Text is deduped per EIN, regardless of which source field it came from,
+    so the string_agg result contains each distinct non-empty snippet exactly
+    once per EIN.
     """
     logger.info("Building %s…", NONPROFIT_TEXT_TABLE)
     session.execute(text(f"DROP TABLE IF EXISTS {NONPROFIT_TEXT_TABLE}"))
     # Every text field gets an equivalent SELECT … WHERE COALESCE(col,'') <> ''
-    # stanza. UNION (not UNION ALL) deduplicates the (src, text) tuples for
-    # us, so a mission statement copy-pasted for 15 years contributes one row.
+    # stanza. The second CTE deduplicates on (ein, txt), so source labels do
+    # not make identical text count more than once for the same nonprofit.
     session.execute(
         text(
             f"""
             CREATE TABLE {NONPROFIT_TEXT_TABLE} AS
             WITH all_text AS (
-                SELECT filerein AS ein, 'mission'::text AS src, mission AS txt
+                SELECT filerein AS ein, mission AS txt
                 FROM public.mission_statements
                 WHERE COALESCE(mission, '') <> ''
-                UNION
-                SELECT filerein, 'programs_1', actividescri1
+                UNION ALL
+                SELECT filerein, actividescri1
                 FROM public.programs
                 WHERE COALESCE(actividescri1, '') <> ''
-                UNION
-                SELECT filerein, 'programs_2', actividescri2
+                UNION ALL
+                SELECT filerein, actividescri2
                 FROM public.programs
                 WHERE COALESCE(actividescri2, '') <> ''
-                UNION
-                SELECT filerein, 'programs_3', actividescri3
+                UNION ALL
+                SELECT filerein, actividescri3
                 FROM public.programs
                 WHERE COALESCE(actividescri3, '') <> ''
-                UNION
-                SELECT filerein, 'schedule_o_part_iii', supinfdetexp
+                UNION ALL
+                SELECT filerein, supinfdetexp
                 FROM {SCHEDULE_O_PART_III_TABLE}
                 WHERE COALESCE(supinfdetexp, '') <> ''
+            ),
+            unique_snippets AS (
+                SELECT DISTINCT ein, txt
+                FROM all_text
             ),
             per_ein AS (
                 SELECT
                     ein,
                     COUNT(*)                                   AS n_source_rows,
-                    string_agg(txt, E'\\n\\n' ORDER BY src, txt) AS unique_text
-                FROM all_text
+                    string_agg(txt, E'\\n\\n' ORDER BY txt)      AS unique_text
+                FROM unique_snippets
                 GROUP BY ein
             )
             SELECT

--- a/givingtuesday_datamart/client/client.py
+++ b/givingtuesday_datamart/client/client.py
@@ -35,6 +35,7 @@ from givingtuesday_datamart.client.models import (
 logger = logging.getLogger(__name__)
 
 GranteeOrGranter = Literal["grantee", "granter"]
+NonprofitSearchMode = Literal["stemmed", "exact"]
 
 DEFAULT_DATABASE = "gt_datamart"
 DEFAULT_PORT = 5432
@@ -48,6 +49,11 @@ ENV_PORT = "GT_DATAMART_PG_PORT"
 ENV_USER = "GT_DATAMART_PG_USER"
 ENV_PASSWORD = "GT_DATAMART_PG_PASSWORD"
 ENV_DATABASE = "GT_DATAMART_PG_DATABASE"
+
+
+def _escape_like(value: str) -> str:
+    """Escape user input for a parameterized LIKE/ILIKE pattern."""
+    return value.replace("!", "!!").replace("%", "!%").replace("_", "!_")
 
 
 def _engine_from_components(
@@ -135,6 +141,7 @@ class GtDatamartClient:
         self,
         keywords: list[str],
         *,
+        search_mode: NonprofitSearchMode = "stemmed",
         return_text: bool = False,
         min_rank: float | None = None,
         limit: int | None = None,
@@ -142,9 +149,10 @@ class GtDatamartClient:
         """Postgres FTS over ``public.nonprofit_text.text_tsv``.
 
         Each keyword is bound as a separate parameter and run through
-        ``plainto_tsquery('english', :kw)``; the per-keyword tsqueries are
-        OR-ed together with ``||``. ``plainto_tsquery`` handles multi-word
-        phrases and special characters cleanly without manual escaping.
+        ``phraseto_tsquery('english', :kw)`` in ``stemmed`` mode; the
+        per-keyword tsqueries are OR-ed together with ``||``. In ``exact``
+        mode, each keyword is matched as a case-insensitive raw phrase against
+        ``unique_text`` without stemming.
 
         ``LEFT JOIN nonprofit_canonical`` because ~46K 990-EZ filers live in
         ``nonprofit_text`` but are missing from ``nonprofit_canonical``
@@ -154,31 +162,47 @@ class GtDatamartClient:
         cleaned = [kw.strip() for kw in keywords if kw and kw.strip()]
         if not cleaned:
             raise ValueError("search_nonprofits requires at least one non-empty keyword")
+        if search_mode not in ("stemmed", "exact"):
+            raise ValueError("search_mode must be 'stemmed' or 'exact'")
 
-        # Build the tsquery as a chain of plainto_tsquery(:kwN) || …
-        # parameterized — never interpolate user input into SQL text.
-        tsquery_terms = " || ".join(
-            f"plainto_tsquery('english', :kw{i})" for i in range(len(cleaned))
-        )
-        params: dict[str, object] = {f"kw{i}": kw for i, kw in enumerate(cleaned)}
+        if search_mode == "stemmed":
+            # Build the tsquery as a chain of phraseto_tsquery(:kwN) || ...
+            # parameterized — never interpolate user input into SQL text.
+            query_expr = " || ".join(
+                f"phraseto_tsquery('english', :kw{i})" for i in range(len(cleaned))
+            )
+            params: dict[str, object] = {f"kw{i}": kw for i, kw in enumerate(cleaned)}
+            rank_expr = "ts_rank(nt.text_tsv, q.query)"
+            match_expr = "nt.text_tsv @@ q.query"
+            with_clause = f"WITH q AS (SELECT {query_expr} AS query)"
+            cross_join = "CROSS JOIN q"
+        else:
+            match_expr = " OR ".join(
+                f"nt.unique_text ILIKE :kw{i} ESCAPE '!'" for i in range(len(cleaned))
+            )
+            params = {f"kw{i}": f"%{_escape_like(kw)}%" for i, kw in enumerate(cleaned)}
+            rank_expr = "1.0::float8"
+            match_expr = f"({match_expr})"
+            with_clause = ""
+            cross_join = ""
 
         sql = f"""
-            WITH q AS (SELECT {tsquery_terms} AS tsq)
+            {with_clause}
             SELECT
                 nt.ein,
                 nc.name,
                 nc.name_secondary,
                 nc.city,
                 nc.state,
-                ts_rank(nt.text_tsv, q.tsq) AS rank,
+                {rank_expr} AS rank,
                 {"nt.unique_text" if return_text else "NULL"} AS unique_text
             FROM public.nonprofit_text nt
             LEFT JOIN public.nonprofit_canonical nc USING (ein)
-            CROSS JOIN q
-            WHERE nt.text_tsv @@ q.tsq
+            {cross_join}
+            WHERE {match_expr}
         """
         if min_rank is not None:
-            sql += " AND ts_rank(nt.text_tsv, q.tsq) >= :min_rank"
+            sql += f" AND {rank_expr} >= :min_rank"
             params["min_rank"] = min_rank
         sql += " ORDER BY rank DESC"
         if limit is not None:
@@ -186,8 +210,9 @@ class GtDatamartClient:
             params["limit"] = limit
 
         logger.info(
-            "search_nonprofits: %d keyword(s), min_rank=%s, limit=%s",
+            "search_nonprofits: %d keyword(s), search_mode=%s, min_rank=%s, limit=%s",
             len(cleaned),
+            search_mode,
             min_rank,
             limit,
         )


### PR DESCRIPTION
## Summary
- Add a `search_mode` option to `search_nonprofits` with `stemmed` and `exact` modes.
- Use stemmed phrase FTS via `phraseto_tsquery` for the default mode.
- Support exact case-insensitive raw phrase matching against `unique_text`.

## Test plan
- Parsed `givingtuesday_datamart/client/client.py` with Python AST successfully.
- Checked IDE lints for the edited files; no errors reported.