### PR TITLE
Group grouped-grants rows by EIN and label with canonical org name

### DIFF
--- a/frontend/src/lib/queries/grants.ts
+++ b/frontend/src/lib/queries/grants.ts
@@ -239,9 +239,19 @@ export async function getGrantsGivenGrouped(
   const offset = (page - 1) * limit;
 
   const isYear = groupBy === 'year';
-  const groupExpr = isYear
-    ? sql`taxyear::int`
-    : sql`COALESCE(grantee_organization_name1, grantee_person_name, 'Unknown')`;
+  // EIN-when-present, name-when-null. Same EIN under different name castings
+  // collapses into one group; rows without an EIN still group by name.
+  const entityGroupExpr = sql`COALESCE(grantee_ein, '__name:' || COALESCE(grantee_organization_name1, grantee_person_name, 'Unknown'))`;
+  // Display label: prefer canonical names from the org tables; fall back to
+  // the most-common variant on the grant rows themselves for EINs not in
+  // either canonical table.
+  const entityNameExpr = sql`COALESCE(
+    (SELECT name FROM public.nonprofit_canonical WHERE ein = unioned_grants.grantee_ein),
+    (SELECT name FROM public.funder_canonical WHERE ein = unioned_grants.grantee_ein),
+    mode() WITHIN GROUP (ORDER BY COALESCE(grantee_organization_name1, grantee_person_name, 'Unknown')),
+    'Unknown'
+  )`;
+  const groupExpr = isYear ? sql`taxyear::int` : entityNameExpr;
   const groupEinExpr = isYear
     ? sql<string | null>`NULL`
     : sql<string | null>`grantee_ein`;
@@ -262,14 +272,12 @@ export async function getGrantsGivenGrouped(
   if (isYear) {
     groupQuery = groupQuery.groupBy(sql`taxyear::int`);
   } else {
-    groupQuery = groupQuery
-      .groupBy(sql`COALESCE(grantee_organization_name1, grantee_person_name, 'Unknown')`)
-      .groupBy('grantee_ein');
+    groupQuery = groupQuery.groupBy(entityGroupExpr).groupBy('grantee_ein');
   }
 
   const countDistinctExpr = isYear
     ? sql<number>`COUNT(DISTINCT taxyear::int)`
-    : sql<number>`COUNT(DISTINCT COALESCE(grantee_organization_name1, grantee_person_name, 'Unknown'))`;
+    : sql<number>`COUNT(DISTINCT COALESCE(grantee_ein, '__name:' || COALESCE(grantee_organization_name1, grantee_person_name, 'Unknown')))`;
 
   let overallQuery = db
     .selectFrom('public.unioned_grants')
@@ -318,9 +326,14 @@ export async function getGrantsReceivedGrouped(
   const offset = (page - 1) * limit;
 
   const isYear = groupBy === 'year';
-  const groupExpr = isYear
-    ? sql`taxyear::int`
-    : sql`COALESCE(granter_name, 'Unknown')`;
+  const entityGroupExpr = sql`COALESCE(granter_ein, '__name:' || COALESCE(granter_name, 'Unknown'))`;
+  const entityNameExpr = sql`COALESCE(
+    (SELECT name FROM public.nonprofit_canonical WHERE ein = unioned_grants.granter_ein),
+    (SELECT name FROM public.funder_canonical WHERE ein = unioned_grants.granter_ein),
+    mode() WITHIN GROUP (ORDER BY COALESCE(granter_name, 'Unknown')),
+    'Unknown'
+  )`;
+  const groupExpr = isYear ? sql`taxyear::int` : entityNameExpr;
   const groupEinExpr = isYear
     ? sql<string | null>`NULL`
     : sql<string | null>`granter_ein`;
@@ -341,14 +354,12 @@ export async function getGrantsReceivedGrouped(
   if (isYear) {
     groupQuery = groupQuery.groupBy(sql`taxyear::int`);
   } else {
-    groupQuery = groupQuery
-      .groupBy(sql`COALESCE(granter_name, 'Unknown')`)
-      .groupBy('granter_ein');
+    groupQuery = groupQuery.groupBy(entityGroupExpr).groupBy('granter_ein');
   }
 
   const countDistinctExpr = isYear
     ? sql<number>`COUNT(DISTINCT taxyear::int)`
-    : sql<number>`COUNT(DISTINCT COALESCE(granter_name, 'Unknown'))`;
+    : sql<number>`COUNT(DISTINCT COALESCE(granter_ein, '__name:' || COALESCE(granter_name, 'Unknown')))`;
 
   let overallQuery = db
     .selectFrom('public.unioned_grants')


### PR DESCRIPTION
## Summary

The grouped grants table on org pages was splitting the same donor (or grantee) into multiple rows whenever the source filings used different name castings — e.g. *Silicon Valley Community Foundation* and *SILICON VALLEY COMMUNITY FOUNDATION* shared EIN `20-5205488` but rendered as two separate donor rows with different totals.

Both `getGrantsGivenGrouped` and `getGrantsReceivedGrouped` in [`frontend/src/lib/queries/grants.ts`](frontend/src/lib/queries/grants.ts) now:

- **Group by EIN when present**, falling back to name only when the EIN is null. The composite GROUP BY key is `COALESCE(<ein>, '__name:' || COALESCE(<name>, 'Unknown'))`, so name-only variants of the same EIN collapse and EIN-less rows still group on name with no regression.
- **Label each group with the canonical org name** by scalar-subquery lookup in `public.nonprofit_canonical` then `public.funder_canonical` — the same precedence the `/orgs/[ein]` page uses ([`orgs.ts:330-341`](frontend/src/lib/queries/orgs.ts#L330-L341)) — falling back to `mode() WITHIN GROUP (ORDER BY <name>)` for EINs absent from both canonical tables, then `'Unknown'`.
- **Use the same composite key in `COUNT(DISTINCT …)`** so the summary-bar group total agrees with the actual displayed rows.

No frontend or API contract changes. `groupKeyEin` was already returned and is still used to build the `/orgs/[ein]` link and to filter the underlying grants in the expanded sub-rows ([`GrantsTable.tsx:55-58`](frontend/src/components/org/GrantsTable.tsx#L55-L58), [`GrantsTable.tsx:150`](frontend/src/components/org/GrantsTable.tsx#L150)).

### Why this matters

For Silicon Valley Community Foundation as a granter, the distinct-grantee count drops from **18,519 → 13,219** — roughly 5,300 entity rows that were being double- (or n-) counted because of name-casing variants alone.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] On a foundation page (SVCF, `20-5205488`) → Grants Given grouped by entity: Fidelity now appears as a single row, 16 grants under canonical *FIDELITY INVESTMENTS CHARITABLE GIFT FUND* (previously split into *Fidelity Inv Charitable Gift Fund* + *FIDELITY CHARITABLE GIFT FUND* + others)
- [x] On a nonprofit page (Parker Institute, `47-3355381`) → Grants Received grouped by donor: SVCF appears once, 4 grants $364.75M, canonical mixed-case (matches `/orgs/20-5205488`)
- [x] Donor-row link still routes to `/orgs/{ein}`
- [x] Expand chevron still loads the underlying grants (uses unchanged `groupKeyEin`)
- [x] No console / network errors

## Notes for the reviewer

- The scalar-subquery lookup vs. a JOIN: kept the SELECT-with-GROUP-BY shape intact and avoided touching `applyCommonFilters`, since the canonical tables are tiny and indexed on `ein`. If perf comes up later, this is a clean swap to a CTE.
- `mode() WITHIN GROUP (...)` returns the most common name variant in the group with a deterministic alphabetic tiebreak — chosen over `MAX/MIN` because the most-filed casing is usually the cleanest one.
- Out of scope: upstream name normalization in `unioned_grants`, fuzzy matching for EIN-less rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
