### PR TITLE
search_nonprofits: treat 0 as 'no filter' for eligibility thresholds

### DIFF
--- a/givingtuesday_datamart/client/client.py
+++ b/givingtuesday_datamart/client/client.py
@@ -182,14 +182,26 @@ class GtDatamartClient:
           ``min_taxyear`` window must be at least this many.
 
         Any of those filters requires ``min_taxyear`` to be set; raises
-        ``ValueError`` otherwise.
+        ``ValueError`` otherwise. ``None`` and ``0`` are both treated as
+        "filter off"; pass a positive value to apply the threshold.
+        ``min_taxyear`` is only required when at least one threshold is
+        positive.
         """
         cleaned = [kw.strip() for kw in keywords if kw and kw.strip()]
         if not cleaned:
             raise ValueError("search_nonprofits requires at least one non-empty keyword")
 
-        needs_basic = min_avg_contributions is not None
-        needs_grants = min_avg_grants is not None or min_num_grants is not None
+        # Treat both ``None`` and ``0`` as "filter off". ``0`` reads as
+        # "no minimum" to callers, but gating on ``is not None`` alone
+        # would still attach the eligibility CTE + INNER JOIN, which
+        # silently restricts results to EINs present in basic_fields /
+        # unioned_grants for the window — the opposite of the natural
+        # reading. Only a positive threshold actually filters.
+        needs_basic = min_avg_contributions is not None and min_avg_contributions > 0
+        needs_grants = (
+            (min_avg_grants is not None and min_avg_grants > 0)
+            or (min_num_grants is not None and min_num_grants > 0)
+        )
         if (needs_basic or needs_grants) and min_taxyear is None:
             raise ValueError(
                 "min_taxyear is required when any eligibility filter "
@@ -271,10 +283,10 @@ class GtDatamartClient:
             # and min_num_grants is the total grant-row count across the
             # window.
             having_clauses: list[str] = []
-            if min_num_grants is not None:
+            if min_num_grants is not None and min_num_grants > 0:
                 having_clauses.append("SUM(yr_count) >= :min_num_grants")
                 params["min_num_grants"] = min_num_grants
-            if min_avg_grants is not None:
+            if min_avg_grants is not None and min_avg_grants > 0:
                 having_clauses.append("AVG(yr_sum) >= :min_avg_grants")
                 params["min_avg_grants"] = min_avg_grants
             having_sql = " AND ".join(having_clauses)


### PR DESCRIPTION
## What

In `GtDatamartClient.search_nonprofits`, the three optional eligibility filters (`min_avg_contributions`, `min_avg_grants`, `min_num_grants`) now treat `0` and `None` identically — both mean "filter off". A positive value applies the threshold.

## Why

The filters previously gated on `is not None` rather than on the value. That made `min_num_grants=0` (and `min_avg_grants=0`, `min_avg_contributions=0`) silently restrictive:

- `None` → no eligibility CTE, no JOIN. All FTS hits returned.
- `0` → CTE built with `HAVING SUM(yr_count) >= 0` (trivially true), but the `JOIN grant_eligible USING (ein)` still attached. Since `COUNT(*)` per group is always ≥ 1, this filtered results to EINs that appear in `unioned_grants` for the `min_taxyear` window — the *opposite* of how "0 = no minimum" reads.

Worth flagging for reviewers: `min_num_grants=0` and `min_num_grants=1` were equivalent pre-fix (both reduced to "EIN has ≥1 grant in window"). Post-fix, `0` jumps up to the unfiltered count. If any downstream caller was leaning on `0` as a stealth "must have grants" filter, that's the regression vector to check — a quick `git grep` of callers should make it obvious.

## Change

One file, one function: `givingtuesday_datamart/client/client.py` — `search_nonprofits`.

1. Top-level gates: `is not None` → `is not None and > 0`, with an inline comment explaining the JOIN-side-effect that motivated the change.
2. Inner HAVING clauses: same `> 0` gate so a positive `min_num_grants` with `min_avg_grants=0` only emits the count clause.
3. Docstring updated — `None` and `0` are both "filter off"; `min_taxyear` is only required when at least one threshold is positive.

`find_eins_with_min_avg_contributions` is intentionally untouched — `min_avg` is a *required* parameter there, so there's no `None`-vs-`0` confusion to resolve.

## Verification

Verified against the live `gt_datamart` DB with the "geothermal" keyword:

| Filter | None | 0 | positive |
|---|---:|---:|---:|
| `min_num_grants` | 41 | **41** | 31 |
| `min_avg_grants` | 41 | **41** | 21 |
| `min_avg_contributions` | 41 | **41** | 30 |

- `0` and `None` return identical EIN sets across all three filters ✅
- Positive thresholds are strict subsets of the unfiltered set ✅
- `threshold=0` no longer requires `min_taxyear` ✅
- `threshold=1` without `min_taxyear` still raises `ValueError` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)