### PR TITLE
Drop staging tables with CASCADE so matching views don't block refresh

### DIFF
--- a/givingtuesday_datamart/sources/__main__.py
+++ b/givingtuesday_datamart/sources/__main__.py
@@ -21,6 +21,7 @@ Subcommands:
 from __future__ import annotations
 
 import argparse
+import logging
 import sys
 
 from botocore.exceptions import BotoCoreError, ClientError
@@ -29,6 +30,25 @@ from givingtuesday_datamart._internal.logger import logger
 from givingtuesday_datamart.sources.registry import REGISTRY, S3_BUCKET, S3_PREFIX, get_source
 from givingtuesday_datamart.sources.resolver import list_bucket, resolve_latest
 from givingtuesday_datamart.sources.spec import SourceSpec
+
+
+def _configure_cli_logging() -> None:
+    """Attach a console handler so INFO progress lines are visible from the CLI.
+
+    The package logger deliberately ships without handlers (see
+    _internal/logger.py) so library consumers control their own output. But
+    with no handler anywhere, Python's last-resort handler only prints
+    WARNING and above — which silently eats all the per-source progress
+    logging (Starting ingest / Rows written / Created table) when run as a
+    command-line tool.
+    """
+    if logger.handlers:
+        return
+    handler = logging.StreamHandler()
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s %(levelname)s %(message)s", datefmt="%H:%M:%S")
+    )
+    logger.addHandler(handler)
 
 
 def _format_size(size: int) -> str:
@@ -292,7 +312,7 @@ def cmd_refresh(source_names: list[str] | None, *, force: bool) -> int:
 
     exit_code = 0
     summary_rows: list[tuple[str, str, str, str]] = []
-    for spec in specs:
+    for i, spec in enumerate(specs, start=1):
         resolved = resolve_latest(spec, listing=listing)
         if resolved is None:
             logger.error(
@@ -306,6 +326,16 @@ def cmd_refresh(source_names: list[str] | None, *, force: bool) -> int:
             exit_code = 1
             continue
 
+        logger.info(
+            "[%d/%d] %s: latest S3 version %s (%s, %s) -> %s",
+            i,
+            len(specs),
+            spec.logical_name,
+            resolved.version_date,
+            resolved.filename,
+            _format_size(resolved.size),
+            spec.staging_table_name,
+        )
         result = ingest_source(spec, resolved, force=force)
         summary_rows.append(
             (
@@ -379,6 +409,7 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     args = parser.parse_args(argv)
+    _configure_cli_logging()
     if args.command == "status":
         return cmd_status()
     if args.command == "loaded":

--- a/givingtuesday_datamart/write_data_to_sql.py
+++ b/givingtuesday_datamart/write_data_to_sql.py
@@ -114,7 +114,19 @@ def _create_table_from_columns(engine, table_name: str, columns: list[str], over
     col_defs = ', '.join([f'"{col}" TEXT' for col in columns])
     with engine.connect() as conn:
         if overwrite:
-            conn.execute(text(f"DROP TABLE IF EXISTS {table_name}"))
+            # CASCADE: the matching views (grant_matching._VIEW_DDL) sit on top
+            # of the staging tables and block a plain DROP once matching has
+            # run. They are rebuilt by create_or_replace_views() at the start
+            # of every matching run, so dropping them with the table is safe.
+            # Log the server NOTICEs so cascaded drops are visible in the run
+            # log rather than silent.
+            raw = conn.connection.dbapi_connection
+            notices = getattr(raw, "notices", None)
+            if notices is not None:
+                del notices[:]
+            conn.execute(text(f"DROP TABLE IF EXISTS {table_name} CASCADE"))
+            for notice in notices or []:
+                logger.info("DROP %s: %s", table_name, notice.strip())
         conn.execute(text(f"CREATE TABLE IF NOT EXISTS {table_name} ({col_defs})"))
         conn.commit()
     logger.info(f"Created table {table_name} with {len(columns)} columns")


### PR DESCRIPTION
## What

`python -m givingtuesday_datamart.sources refresh` fails with `DependentObjectsStillExist` on `basic_fields` and `basic_fields_pf`:

```
psycopg2.errors.DependentObjectsStillExist: cannot drop table basic_fields because other objects depend on it
DETAIL:  view basic_fields_w_column_keys_view depends on table basic_fields
```

Since #30, the grant-matching views (`grant_matching._VIEW_DDL`) sit on top of the `basic_fields` / `basic_fields_pf` / `privategrants` staging tables, so the plain `DROP TABLE IF EXISTS` in `_create_table_from_columns` is blocked on the first refresh after a matching run.

## Fix

- `DROP TABLE IF EXISTS ... CASCADE` in `_create_table_from_columns`.
- Capture the server NOTICEs (`drop cascades to view ...`) off the raw psycopg2 connection and write them to the run log, so cascaded drops are auditable rather than silent.

## Why CASCADE is safe here

The six views are pipeline-owned, not user-owned: `create_or_replace_views()` (grant_matching.py) rebuilds all of them at the start of every matching run, and nothing else in the repo (canonical build, frontend, SQL files) reads them. The only window where they don't exist is between a refresh and the next matching run, which no other code path touches. The canonical-build `DROP TABLE` sites don't need the same treatment — no views exist on those tables.

## Reviewer notes

- Verified against the installed versions (SQLAlchemy 2.0.44, psycopg2 2.9.11) that `conn.connection.dbapi_connection` yields the raw psycopg2 connection and that it carries the `notices` list; a `getattr` guard covers non-psycopg2 drivers.
- Not exercised against a live Postgres from this machine (no local server); the failing environment is the EC2→RDS refresh. After merging, rerun `refresh` there — the two failed sources will re-ingest without `--force` since their runs are recorded as failed.
- After the staging tables rebuild, the matching pipeline needs its usual rerun, which recreates the views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
