### PR TITLE
basic_fields: pick latest filing version per filer-year in client reads (#34 Phase 1)

### DIFF
--- a/givingtuesday_datamart/client/client.py
+++ b/givingtuesday_datamart/client/client.py
@@ -266,8 +266,19 @@ class GtDatamartClient:
             # non-amended filings — IS NOT DISTINCT FROM keeps the sort key
             # boolean, where a plain = would put NULL first under DESC and
             # prefer the original. filesha256 is a determinism tiebreak:
-            # some filer-years re-drop the same filing under one url. The
-            # staging columns are all-TEXT; cast at query time.
+            # some filer-years re-drop the same filing under one url.
+            #
+            # Contributions-present outranks the amend flag so a version
+            # that doesn't report the metric never wins: 247 filer-years
+            # (2018+) would otherwise read NULL and drop out of the AVG,
+            # from two mechanisms — 140 where the amended return keeps
+            # total revenue but omits the contributions breakdown, and 107
+            # where two accounting periods share one taxyear label and the
+            # newest url is a stub (revenue 0 or near-0). Selection stays
+            # row-level, so every value comes from one real filing rather
+            # than a per-column composite spanning two periods.
+            #
+            # The staging columns are all-TEXT; cast at query time.
             ctes.append(
                 """contrib_eligible AS (
                     SELECT filerein AS ein
@@ -278,6 +289,7 @@ class GtDatamartClient:
                         FROM public.basic_fields
                         WHERE NULLIF(taxyear, '')::int >= :min_taxyear
                         ORDER BY filerein, taxyear,
+                                 (NULLIF(totacashcont, '') IS NOT NULL) DESC,
                                  (amendereturn IS NOT DISTINCT FROM 'X') DESC,
                                  url DESC, filesha256
                     ) yearly
@@ -486,6 +498,19 @@ class GtDatamartClient:
         on the grants side (issue #34). Consumers that sum or average across
         the returned rows would otherwise double-count amended years.
 
+        Version selection prefers a filing that actually reports
+        ``totacashcont``: an amended return sometimes carries total revenue
+        without re-stating the contributions breakdown, and where two
+        accounting periods share one taxyear label the newest url can be a
+        near-empty stub. Both would otherwise blank out contributions the
+        filer did report. The whole row comes from the selected filing —
+        values are never COALESCEd across versions, which in the
+        split-period case would blend two different accounting periods into
+        a row matching no real filing. Consequence worth knowing: when the
+        amendment omits contributions, ``total_revenue_current_year`` comes
+        from the earlier version too, so it can trail an amended revenue
+        figure by a small amount.
+
         Staging is all-TEXT, so every numeric column is cast at query time
         via ``NULLIF(col, '')::bigint``. ``governgrants`` is COALESCEd to 0
         when computing ``total_cash_contributions_no_gov`` because empty
@@ -522,6 +547,7 @@ class GtDatamartClient:
             params["min_taxyear"] = min_taxyear
         sql += """
             ORDER BY filerein, taxyear,
+                     (NULLIF(totacashcont, '') IS NOT NULL) DESC,
                      (amendereturn IS NOT DISTINCT FROM 'X') DESC,
                      url DESC, filesha256
         """
@@ -747,7 +773,9 @@ class GtDatamartClient:
         # latest version per year (amended preferred, MAX(url) tiebreak,
         # filesha256 for determinism — the current_grants.py rule), then
         # average across years; summing versions double-counts amended years
-        # (issue #34).
+        # (issue #34). Presence of the thresholded column outranks the amend
+        # flag so a version that doesn't report it never wins and silently
+        # drops the year from the AVG — see the note in search_nonprofits.
         sql = f"""
             SELECT filerein AS ein
             FROM (
@@ -758,6 +786,7 @@ class GtDatamartClient:
                 WHERE filerein = ANY(:eins)
                   AND NULLIF(taxyear, '')::int >= :min_taxyear
                 ORDER BY filerein, taxyear,
+                         (NULLIF({column}, '') IS NOT NULL) DESC,
                          (amendereturn IS NOT DISTINCT FROM 'X') DESC,
                          url DESC, filesha256
             ) yearly

--- a/givingtuesday_datamart/client/client.py
+++ b/givingtuesday_datamart/client/client.py
@@ -256,22 +256,33 @@ class GtDatamartClient:
         joins: list[str] = []
 
         if needs_basic:
-            # ``basic_fields`` can have multiple rows per (filerein, taxyear),
-            # so sum within each year first and then take the mean across
-            # years — averaging the raw rows would weight by row count.
-            # The staging columns are all-TEXT; cast at query time.
+            # ``basic_fields`` carries one row per *filing version* — when a
+            # filer amends a return, the original and amended filings are
+            # both present for the same (filerein, taxyear). Keep only the
+            # latest version per year (amended preferred, MAX(url) tiebreak
+            # — the same rule current_grants.py applies on the grants side),
+            # then average across years; summing versions double-counts
+            # amended years (issue #34). The amend flag is NULL (not '') on
+            # non-amended filings — IS NOT DISTINCT FROM keeps the sort key
+            # boolean, where a plain = would put NULL first under DESC and
+            # prefer the original. filesha256 is a determinism tiebreak:
+            # some filer-years re-drop the same filing under one url. The
+            # staging columns are all-TEXT; cast at query time.
             ctes.append(
                 """contrib_eligible AS (
                     SELECT filerein AS ein
                     FROM (
-                        SELECT filerein, taxyear,
-                               SUM(NULLIF(totacashcont, '')::bigint) AS yr_sum
+                        SELECT DISTINCT ON (filerein, taxyear)
+                               filerein, taxyear,
+                               NULLIF(totacashcont, '')::bigint AS yr_val
                         FROM public.basic_fields
                         WHERE NULLIF(taxyear, '')::int >= :min_taxyear
-                        GROUP BY filerein, taxyear
+                        ORDER BY filerein, taxyear,
+                                 (amendereturn IS NOT DISTINCT FROM 'X') DESC,
+                                 url DESC, filesha256
                     ) yearly
                     GROUP BY filerein
-                    HAVING AVG(yr_sum) >= :min_avg_contributions
+                    HAVING AVG(yr_val) >= :min_avg_contributions
                 )"""
             )
             joins.append("JOIN contrib_eligible USING (ein)")
@@ -468,6 +479,13 @@ class GtDatamartClient:
     ) -> list[BasicFieldsRow]:
         """Multi-year staging reads from ``public.basic_fields``.
 
+        Returns one row per (filerein, taxyear): ``basic_fields`` carries one
+        row per *filing version* (original + amended returns under the same
+        filer-year), and this method keeps only the latest version — amended
+        preferred, MAX(url) tiebreak, the same rule current_grants.py applies
+        on the grants side (issue #34). Consumers that sum or average across
+        the returned rows would otherwise double-count amended years.
+
         Staging is all-TEXT, so every numeric column is cast at query time
         via ``NULLIF(col, '')::bigint``. ``governgrants`` is COALESCEd to 0
         when computing ``total_cash_contributions_no_gov`` because empty
@@ -480,7 +498,7 @@ class GtDatamartClient:
 
         params: dict[str, object] = {"eins": list(eins)}
         sql = """
-            SELECT
+            SELECT DISTINCT ON (filerein, taxyear)
                 filerein                                AS ein,
                 filername1                              AS name,
                 filername2                              AS name_secondary,
@@ -502,6 +520,11 @@ class GtDatamartClient:
         if min_taxyear is not None:
             sql += " AND NULLIF(taxyear, '')::int >= :min_taxyear"
             params["min_taxyear"] = min_taxyear
+        sql += """
+            ORDER BY filerein, taxyear,
+                     (amendereturn IS NOT DISTINCT FROM 'X') DESC,
+                     url DESC, filesha256
+        """
 
         with self._session() as session:
             rows = session.execute(text(sql), params).mappings().all()
@@ -719,23 +742,27 @@ class GtDatamartClient:
             "min_taxyear": min_taxyear,
             "min_avg": min_avg,
         }
-        # ``basic_fields`` can have multiple rows for the same (filerein,
-        # taxyear), so sum the duplicates within each year first and then
-        # average across years. ``AVG(col)`` directly over all rows would
-        # weight by row count and quietly drop EINs whose duplicates pulled
-        # the all-rows mean below the threshold.
+        # ``basic_fields`` carries one row per *filing version* for the same
+        # (filerein, taxyear) — original + amended returns. Keep only the
+        # latest version per year (amended preferred, MAX(url) tiebreak,
+        # filesha256 for determinism — the current_grants.py rule), then
+        # average across years; summing versions double-counts amended years
+        # (issue #34).
         sql = f"""
             SELECT filerein AS ein
             FROM (
-                SELECT filerein, taxyear,
-                       SUM(NULLIF({column}, '')::bigint) AS yr_sum
+                SELECT DISTINCT ON (filerein, taxyear)
+                       filerein, taxyear,
+                       NULLIF({column}, '')::bigint AS yr_val
                 FROM public.basic_fields
                 WHERE filerein = ANY(:eins)
                   AND NULLIF(taxyear, '')::int >= :min_taxyear
-                GROUP BY filerein, taxyear
+                ORDER BY filerein, taxyear,
+                         (amendereturn IS NOT DISTINCT FROM 'X') DESC,
+                         url DESC, filesha256
             ) yearly
             GROUP BY filerein
-            HAVING AVG(yr_sum) >= :min_avg
+            HAVING AVG(yr_val) >= :min_avg
         """
         logger.info(
             "find_eins_with_min_avg_contributions: %d EIN(s), column=%s, min_taxyear=%s, min_avg=%s",


### PR DESCRIPTION
Phase 1 of #34 — the contained, client-only fix. Phase 2 (`basic_fields_current` relations in `current_grants.py` + the frontend cutover/audit) follows in a separate PR and will simplify these inline queries to plain reads.

## What changed

`basic_fields` carries one row per **filing version** (original + amended returns under the same `(filerein, taxyear)`). Three client read sites treated those rows as partial components to SUM, doubling contributions for every amended filer-year. All three now select the latest version per filer-year with `DISTINCT ON`, using the rule `current_grants.py` already applies on the grants side — prefer `amendereturn = 'X'`, tiebreak `MAX(url)`, `filesha256` for determinism:

1. `search_nonprofits` → `contrib_eligible` CTE (`min_avg_contributions` eligibility)
2. `get_basic_fields` — now returns one row per `(filerein, taxyear)` instead of one per filing (the intended semantic fix for issue surface 2; docstring updated)
3. `find_eins_with_min_avg_contributions`

No other in-repo consumers of these methods exist; the frontend reads staging through its own pg pool and is Phase 2 scope.

## Gotcha worth knowing: the amend flag is NULL, not `''`

Non-amended filings have `amendereturn = NULL`. A sort key of `(amendereturn = 'X') DESC` evaluates to NULL for them, and Postgres sorts NULLs **first** under `DESC` — silently preferring the *original* over the amendment. First validation run caught exactly this (3/5 spot-checks picked the wrong version). The fix uses `(amendereturn IS NOT DISTINCT FROM 'X') DESC`, which is never NULL. Note the issue's reproduction query has the same subtlety in its `ARRAY_AGG` ordering (`current_grants.py` is immune — it wraps the flag in `COALESCE(BOOL_OR(...), FALSE)`); the aggregate numbers barely move, but Phase 2's DDL should use the `IS NOT DISTINCT FROM` form.

## Pre-check findings (current staging, 2026-08-05)

- **Row grain**: `basic_fields` has 3,939,773 rows vs 3,897,291 distinct `(filerein, taxyear, filesha256)` — ~42K rows are duplicated *within the same filing*, so the old SUM inflated even some single-version years. 23,365 filer-years carry multiple shas under a single url (hence the `filesha256` determinism tiebreak).
- **Short-period edge**: of 80,966 multi-sha 990 filer-years, 3,054 (3.8%) have >1 distinct `taxperend` — potentially two legitimate short-period returns in one taxyear, which this rule (like the #33 grants rule) collapses to one. Known conservative characteristic of the shared rule; documented here rather than diverging from it.
- **Canonical ordering (issue surface 4, for Phase 2)**: 5,315 EINs have >1 filing version in `nonprofit_canonical`'s winning `(taxyear, taxperend)` group; identity fields actually differ for **619** — so the arbitrary pick is real but cosmetic. Phase 2 resolves it by pointing the canonical build at `basic_fields_current`.

## Validation (run against the live DB with this branch's code)

```
=== B. issue repro, taxyear >= 2018
    filer-years: 2,182,968  multi-version: 101,543
    version-SUM total: $5,145.3B  latest-only total: $4,835.0B  inflation: $310.3B
=== C. eligibility delta, old CTE shape vs new (min_taxyear=2018)
    min_avg=    100,000: old=258,453  new=256,183  dropped= 2,277  added=7
    min_avg=  1,000,000: old= 74,021  new= 71,155  dropped= 2,871  added=5
    min_avg= 10,000,000: old= 11,103  new= 10,436  dropped=   667  added=0
=== D. amended filer-year spot-check via client.get_basic_fields
    OK  ein=010096117 year=2010 versions=2  rows_returned=1  got=248559  latest=248559  old_sum=456168
    OK  ein=010211481 year=2017 versions=2  rows_returned=1  got=15698   latest=15698   old_sum=16380
    OK  ein=010211486 year=2015 versions=2  rows_returned=1  got=319232  latest=319232  old_sum=638464
    OK  ein=010211486 year=2018 versions=2  rows_returned=1  got=430211  latest=430211  old_sum=935640
    OK  ein=010211486 year=2019 versions=2  rows_returned=1  got=904048  latest=904048  old_sum=1657822
=== E. end-to-end smoke
    search_nonprofits('food bank', min_avg_contributions=1M): 5 hits
```

Reading the delta: EINs "dropped" are amended filers whose version-summed average cleared a threshold their true latest-version average does not (per the issue's acceptance checks, some EINs legitimately drop out). The handful "added" are years whose latest version has NULL contributions — the year now falls out of the AVG instead of contributing a partial sum. The repro matches the issue's measured impact ($310B / 4.7% multi-version filer-years).

## Regression gate

None of the current gate checks read `basic_fields` aggregates; no gate run needed. The matcher's universe views are untouched (no `MATCHING_INPUT_SHAPE_VERSION` implications) — the migrate-or-not decision for those views is documented in #34 and lands with Phase 2.

Refs #34 (closes after Phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
