### PR TITLE
Identity resolution for GtDatamartClient: ranked search, batched and single-row

### DIFF
--- a/givingtuesday_datamart/client/__init__.py
+++ b/givingtuesday_datamart/client/__init__.py
@@ -3,16 +3,20 @@
 from givingtuesday_datamart.client.client import GtDatamartClient
 from givingtuesday_datamart.client.models import (
     BasicFieldsRow,
+    CanonicalIdentity,
     Grant,
     GrantSummary,
     IdentityHit,
+    IdentityQuery,
     Nonprofit,
     NonprofitHit,
 )
 
 __all__ = [
     "GtDatamartClient",
+    "CanonicalIdentity",
     "IdentityHit",
+    "IdentityQuery",
     "NonprofitHit",
     "Nonprofit",
     "BasicFieldsRow",

--- a/givingtuesday_datamart/client/__init__.py
+++ b/givingtuesday_datamart/client/__init__.py
@@ -5,12 +5,14 @@ from givingtuesday_datamart.client.models import (
     BasicFieldsRow,
     Grant,
     GrantSummary,
+    IdentityHit,
     Nonprofit,
     NonprofitHit,
 )
 
 __all__ = [
     "GtDatamartClient",
+    "IdentityHit",
     "NonprofitHit",
     "Nonprofit",
     "BasicFieldsRow",

--- a/givingtuesday_datamart/client/client.py
+++ b/givingtuesday_datamart/client/client.py
@@ -42,11 +42,11 @@ GranteeOrGranter = Literal["grantee", "granter"]
 SearchMode = Literal["stemmed", "exact"]
 IdentityOrgType = Literal["all", "nonprofit", "funder"]
 
-# Ranking tiers for ``search_identity``, ported verbatim from the frontend's
+# Ranking tiers for ``search_identity``, ported from the frontend's
 # ``searchOrgs`` query (frontend/src/lib/queries/search.ts). Tiers are
-# separated by wide ranges so a tier always beats every lower tier; narrative
-# FTS uses raw ``ts_rank_cd`` scores (typically 0–~50), which always sort
-# below the fixed tiers.
+# separated by wide ranges so a tier always beats every lower tier. The
+# frontend's fifth tier — narrative FTS at raw ``ts_rank_cd`` — is
+# intentionally not ported; see ``search_identity`` for why.
 IDENTITY_RANK_EIN = 2_000_000.0
 IDENTITY_RANK_URL_EXACT = 1_500_000.0
 IDENTITY_RANK_URL_PREFIX = 1_200_000.0
@@ -519,7 +519,6 @@ class GtDatamartClient:
         name: str | None,
         domain: str,
         ein_digits: str,
-        include_narrative: bool,
         limit: int | None,
     ) -> tuple[str, dict[str, object]]:
         """Assemble one arm of the ``search_identity`` query.
@@ -558,20 +557,6 @@ class GtDatamartClient:
             unions.append("SELECT ein, rank, signal FROM name_hits")
             params["like"] = f"%{name}%"
 
-        if arm == "nonprofit" and name is not None and include_narrative:
-            ctes.append(
-                """fts_hits AS (
-                    SELECT nt.ein,
-                           ts_rank_cd(nt.text_tsv_compact, q)::float8 AS rank,
-                           'narrative' AS signal
-                    FROM public.nonprofit_text nt,
-                         websearch_to_tsquery('english', :raw_name) AS q
-                    WHERE nt.text_tsv_compact @@ q
-                )"""
-            )
-            unions.append("SELECT ein, rank, signal FROM fts_hits")
-            params["raw_name"] = name
-
         if ein_digits:
             ctes.append(
                 f"""ein_hits AS (
@@ -603,11 +588,12 @@ class GtDatamartClient:
             params["domain"] = domain
             params["domain_prefix"] = f"{domain}%"
 
-        # LEFT JOIN on the nonprofit arm because narrative hits can be
-        # 990-EZ filers absent from nonprofit_canonical — they come back
-        # with NULL identity columns (same contract as search_nonprofits).
-        # The funder arm's sources are all funder_canonical itself, so its
-        # join is definitionally inner.
+        # Every remaining signal source selects from the canonical itself, so
+        # this LEFT JOIN is now provably equivalent to an inner one — it can
+        # no longer surface the 990-EZ filers (present in nonprofit_text,
+        # absent from nonprofit_canonical) that the dropped narrative arm
+        # used to reach. Kept as LEFT so adding a nonprofit_text-sourced
+        # signal later doesn't silently start dropping rows.
         join = (
             "LEFT JOIN public.nonprofit_canonical c USING (ein)"
             if arm == "nonprofit"
@@ -656,7 +642,6 @@ class GtDatamartClient:
         ein: str | None = None,
         *,
         org_type: IdentityOrgType = "all",
-        include_narrative: bool = True,
         limit: int | None = 25,
     ) -> list[IdentityHit]:
         """Multi-signal ranked identity search, ported from the frontend's
@@ -678,28 +663,32 @@ class GtDatamartClient:
           upstream, don't pass raw customer junk like ``"N/A"``.
         * ``name`` — ILIKE substring over ``name`` / ``name_secondary``
           (plus ``dba_1`` / ``dba_2`` on the nonprofit arm) at rank
-          1,000,000, UNIONed with narrative FTS over
-          ``nonprofit_text.text_tsv_compact`` via
-          ``websearch_to_tsquery('english', ...)`` ranked by raw
-          ``ts_rank_cd`` (typically 0–~50, always below the fixed tiers).
-          Set ``include_narrative=False`` to search names only.
+          1,000,000.
 
-        Two arms, mirroring the frontend: ``nonprofit_canonical`` (all
-        signals) and ``funder_canonical`` (name + EIN only — funders have no
-        URL or narrative surface yet). ``org_type`` restricts to one arm;
-        a funder-only search with just a ``url`` has nothing to match and
-        returns ``[]``. Each EIN collapses to its best rank per arm, with
+        Identity signals only. The frontend's narrative-FTS arm is
+        deliberately **not** ported: a topical match on 990 program text is
+        not evidence of identity, and mixing its raw ``ts_rank_cd`` scores
+        (~0–50) into a list topped by fixed 1,000,000+ tiers means a weak
+        topical hit lands at rank 1 whenever no real identity signal matches.
+        Measured on a live portfolio, it bought ~4 points of recall while
+        doubling the wrong-at-rank-1 rate, and on rows with no EIN it was
+        wrong nearly every time ("Freedom River Well Project" → CRAG LAW
+        CENTER). Use ``search_nonprofits`` for narrative/topical discovery —
+        that's the method built for it, and it returns FTS ranks unmixed
+        with identity tiers.
+
+        Two arms: ``nonprofit_canonical`` (all three signals) and
+        ``funder_canonical`` (name + EIN only — funders have no website, so
+        no domain column). ``org_type`` restricts to one arm; a funder-only
+        search with just a ``url`` has nothing to match and returns ``[]``.
+        Each EIN collapses to its best rank per arm, with
         ``IdentityHit.signal`` naming the winning signal.
-
-        The nonprofit arm LEFT JOINs ``nonprofit_canonical``, so ~46K 990-EZ
-        filers reachable only through the narrative signal return with NULL
-        identity columns (same contract as ``search_nonprofits``).
 
         ``limit`` is pushed into each arm's SQL, then the arms are merged
         and re-sliced here (rank DESC, latest_taxyear DESC nulls-last, name,
         ein — the frontend's exact ordering), so worst case ``2 * limit``
         rows cross the wire. ``limit=None`` returns everything; fine for
-        EIN/URL lookups, unbounded for broad name/narrative queries.
+        EIN/URL lookups, unbounded for a broad name substring.
         """
         if org_type not in ("all", "nonprofit", "funder"):
             raise ValueError(
@@ -725,13 +714,11 @@ class GtDatamartClient:
             return []
 
         logger.info(
-            "search_identity: signals(name=%s, url=%s, ein=%s), org_type=%s, "
-            "include_narrative=%s, limit=%s",
+            "search_identity: signals(name=%s, url=%s, ein=%s), org_type=%s, limit=%s",
             name is not None,
             bool(domain),
             bool(ein_digits),
             org_type,
-            include_narrative,
             limit,
         )
 
@@ -745,7 +732,6 @@ class GtDatamartClient:
                     name=name,
                     domain=domain,
                     ein_digits=ein_digits,
-                    include_narrative=include_narrative,
                     limit=limit,
                 )
                 rows = session.execute(text(sql), params).mappings().all()
@@ -781,7 +767,6 @@ class GtDatamartClient:
         has_name: bool,
         has_domain: bool,
         has_ein: bool,
-        include_narrative: bool,
         include_url_prefix: bool,
         limit_per_query: int | None,
     ) -> str:
@@ -820,23 +805,6 @@ class GtDatamartClient:
                 )"""
             )
             unions.append("SELECT key, ein, rank, signal FROM name_hits")
-
-        if arm == "nonprofit" and has_name and include_narrative:
-            # tsquery built once per input row in the subselect, then matched
-            # against the GIN index — indexed lookup per row, not a scan.
-            ctes.append(
-                """fts_hits AS (
-                    SELECT q.key, nt.ein,
-                           ts_rank_cd(nt.text_tsv_compact, q.tsq)::float8 AS rank,
-                           'narrative' AS signal
-                    FROM (
-                        SELECT key, websearch_to_tsquery('english', val) AS tsq
-                        FROM unnest(:fts_keys ::text[], :fts_vals ::text[]) AS t(key, val)
-                    ) q
-                    JOIN public.nonprofit_text nt ON nt.text_tsv_compact @@ q.tsq
-                )"""
-            )
-            unions.append("SELECT key, ein, rank, signal FROM fts_hits")
 
         if has_ein:
             ctes.append(
@@ -877,6 +845,8 @@ class GtDatamartClient:
                 )
                 unions.append("SELECT key, ein, rank, signal FROM url_prefix_hits")
 
+        # LEFT for the same defensive reason as the single-row path — every
+        # current source selects from the canonical, so it can't yield NULLs.
         join = (
             "LEFT JOIN public.nonprofit_canonical c USING (ein)"
             if arm == "nonprofit"
@@ -931,7 +901,6 @@ class GtDatamartClient:
         queries: Sequence[IdentityQuery],
         *,
         org_type: IdentityOrgType = "all",
-        include_narrative: bool = True,
         include_url_prefix: bool = False,
         limit_per_query: int | None = 25,
         chunk_size: int = 500,
@@ -960,7 +929,6 @@ class GtDatamartClient:
           still saves the round trips — roughly 30% — but not the scans).
           Budget ~0.5s per named row. Above a few hundred name-only rows,
           prefer ``iter_identity_universe`` and match in process.
-        * narrative FTS — GIN-indexed, so it stays an indexed lookup per row.
 
         ``chunk_size`` bounds both the array-parameter size and the length of
         any single transaction; progress is logged per chunk. Lower it for
@@ -975,8 +943,11 @@ class GtDatamartClient:
         use it when feeding unwashed customer data where ``"N/A"`` in a URL
         column shouldn't sink 5,000 good rows.
 
-        ``org_type``, ``include_narrative``, and the ranking tiers behave
-        exactly as in ``search_identity``.
+        ``org_type`` and the ranking tiers behave exactly as in
+        ``search_identity`` — including the deliberate absence of a narrative
+        signal, which is a topical match rather than identity evidence. See
+        that method's docstring for why, and use ``search_nonprofits`` when
+        narrative discovery is what you actually want.
         """
         if org_type not in ("all", "nonprofit", "funder"):
             raise ValueError(
@@ -1024,12 +995,11 @@ class GtDatamartClient:
         total_chunks = (len(normalized) + chunk_size - 1) // chunk_size
         logger.info(
             "search_identity_bulk: %d queries in %d chunk(s) of %d, org_type=%s, "
-            "include_narrative=%s, include_url_prefix=%s, limit_per_query=%s",
+            "include_url_prefix=%s, limit_per_query=%s",
             len(normalized),
             total_chunks,
             chunk_size,
             org_type,
-            include_narrative,
             include_url_prefix,
             limit_per_query,
         )
@@ -1063,8 +1033,6 @@ class GtDatamartClient:
                 base_params: dict[str, object] = {
                     "name_keys": name_keys,
                     "name_vals": name_vals,
-                    "fts_keys": name_keys,
-                    "fts_vals": name_vals,
                     "url_keys": url_keys,
                     "url_vals": url_vals,
                     "ein_keys": ein_keys,
@@ -1074,7 +1042,7 @@ class GtDatamartClient:
                     base_params["limit_per_query"] = limit_per_query
 
                 for arm, run in (("nonprofit", run_nonprofit), ("funder", run_funder)):
-                    # The funder arm has no URL or narrative surface, so a
+                    # The funder arm has no URL surface, so a
                     # chunk carrying only URLs gives it nothing to match.
                     if not run:
                         continue
@@ -1085,7 +1053,6 @@ class GtDatamartClient:
                         has_name=has_name,
                         has_domain=has_domain,
                         has_ein=has_ein,
-                        include_narrative=include_narrative,
                         include_url_prefix=include_url_prefix,
                         limit_per_query=limit_per_query,
                     )

--- a/givingtuesday_datamart/client/client.py
+++ b/givingtuesday_datamart/client/client.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+from collections.abc import Sequence
 from contextlib import contextmanager
 from typing import Iterator, Literal
 
@@ -25,9 +26,11 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from givingtuesday_datamart.client.models import (
     BasicFieldsRow,
+    CanonicalIdentity,
     Grant,
     GrantSummary,
     IdentityHit,
+    IdentityQuery,
     Nonprofit,
     NonprofitHit,
 )
@@ -98,6 +101,56 @@ def _engine_from_components(
         database=database,
     )
     return create_engine(url, future=True)
+
+
+def _normalize_identity_signals(
+    name: str | None,
+    url: str | None,
+    ein: str | None,
+    *,
+    strict: bool = True,
+) -> tuple[str | None, str, str]:
+    """Normalize the three identity signals to ``(name, domain, ein_digits)``.
+
+    Shared by ``search_identity`` and ``search_identity_bulk`` so the two
+    paths can't drift on what counts as a usable signal. Blank/whitespace
+    names, unparseable EINs, and non-domain URLs all collapse to "absent".
+
+    With ``strict=True`` a malformed ``ein`` or ``url`` raises ``ValueError``
+    rather than silently degrading the search (a name-only fallback on a
+    typo'd EIN is a wrong-match risk). With ``strict=False`` the bad signal
+    is dropped and the caller decides what to do with a query that ends up
+    with no signals at all.
+    """
+    name = name.strip() if name is not None and name.strip() else None
+
+    ein_digits = ""
+    if ein is not None:
+        digits = re.sub(r"\D", "", ein)
+        if len(digits) == 9:
+            ein_digits = digits
+        elif strict:
+            raise ValueError(f"ein must contain exactly 9 digits, got {ein!r}")
+
+    domain = ""
+    if url is not None:
+        domain = _normalize_domain(url)
+        if not domain and strict:
+            raise ValueError(f"url does not normalize to a searchable domain: {url!r}")
+
+    return name, domain, ein_digits
+
+
+def _identity_sort_key(hit: IdentityHit) -> tuple:
+    """Frontend's cross-arm ordering: rank DESC, latest_taxyear DESC nulls
+    last, name ASC nulls last, ein ASC."""
+    return (
+        -hit.rank,
+        -(hit.latest_taxyear if hit.latest_taxyear is not None else -1),
+        hit.name is None,
+        hit.name or "",
+        hit.ein,
+    )
 
 
 def _normalize_domain(raw: str) -> str:
@@ -653,23 +706,7 @@ class GtDatamartClient:
                 f"org_type must be 'all', 'nonprofit', or 'funder', got {org_type!r}"
             )
 
-        name = name.strip() if name is not None and name.strip() else None
-
-        ein_digits = ""
-        if ein is not None:
-            ein_digits = re.sub(r"\D", "", ein)
-            if len(ein_digits) != 9:
-                raise ValueError(
-                    f"ein must contain exactly 9 digits, got {ein!r}"
-                )
-
-        domain = ""
-        if url is not None:
-            domain = _normalize_domain(url)
-            if not domain:
-                raise ValueError(
-                    f"url does not normalize to a searchable domain: {url!r}"
-                )
+        name, domain, ein_digits = _normalize_identity_signals(name, url, ein)
 
         if name is None and not ein_digits and not domain:
             raise ValueError(
@@ -731,19 +768,449 @@ class GtDatamartClient:
 
         # Cross-arm merge with the frontend's exact ordering; NULL taxyears
         # and names sort last within their rank tier.
-        hits.sort(
-            key=lambda h: (
-                -h.rank,
-                -(h.latest_taxyear if h.latest_taxyear is not None else -1),
-                h.name is None,
-                h.name or "",
-                h.ein,
-            )
-        )
+        hits.sort(key=_identity_sort_key)
         if limit is not None:
             hits = hits[:limit]
         logger.info("search_identity: %d hits", len(hits))
         return hits
+
+    @staticmethod
+    def _identity_bulk_arm_sql(
+        *,
+        arm: Literal["nonprofit", "funder"],
+        has_name: bool,
+        has_domain: bool,
+        has_ein: bool,
+        include_narrative: bool,
+        include_url_prefix: bool,
+        limit_per_query: int | None,
+    ) -> str:
+        """Assemble one arm of the batched query.
+
+        Same tiers and same output shape as ``_identity_arm_sql``, but every
+        signal CTE joins against an ``unnest``-ed array of (key, value) pairs
+        instead of a scalar bind, so N input rows cost one round trip per arm
+        rather than N. Results are keyed by the caller's ``key`` throughout.
+        """
+        table = (
+            "public.nonprofit_canonical" if arm == "nonprofit" else "public.funder_canonical"
+        )
+        ctes: list[str] = []
+        unions: list[str] = []
+
+        if has_name:
+            name_cols = (
+                ["name", "name_secondary", "dba_1", "dba_2"]
+                if arm == "nonprofit"
+                else ["name", "name_secondary"]
+            )
+            # Nested loop: one scan per input name. ILIKE '%x%' is
+            # unindexable, so this is the expensive arm — see the
+            # iter_identity_universe docstring for the local-match
+            # alternative when names dominate the batch.
+            on_clause = " OR ".join(
+                f"c.{col} ILIKE '%' || q.val || '%'" for col in name_cols
+            )
+            ctes.append(
+                f"""name_hits AS (
+                    SELECT q.key, c.ein, {IDENTITY_RANK_NAME}::float8 AS rank,
+                           'name' AS signal
+                    FROM unnest(:name_keys ::text[], :name_vals ::text[]) AS q(key, val)
+                    JOIN {table} c ON {on_clause}
+                )"""
+            )
+            unions.append("SELECT key, ein, rank, signal FROM name_hits")
+
+        if arm == "nonprofit" and has_name and include_narrative:
+            # tsquery built once per input row in the subselect, then matched
+            # against the GIN index — indexed lookup per row, not a scan.
+            ctes.append(
+                """fts_hits AS (
+                    SELECT q.key, nt.ein,
+                           ts_rank_cd(nt.text_tsv_compact, q.tsq)::float8 AS rank,
+                           'narrative' AS signal
+                    FROM (
+                        SELECT key, websearch_to_tsquery('english', val) AS tsq
+                        FROM unnest(:fts_keys ::text[], :fts_vals ::text[]) AS t(key, val)
+                    ) q
+                    JOIN public.nonprofit_text nt ON nt.text_tsv_compact @@ q.tsq
+                )"""
+            )
+            unions.append("SELECT key, ein, rank, signal FROM fts_hits")
+
+        if has_ein:
+            ctes.append(
+                f"""ein_hits AS (
+                    SELECT q.key, c.ein, {IDENTITY_RANK_EIN}::float8 AS rank,
+                           'ein' AS signal
+                    FROM unnest(:ein_keys ::text[], :ein_vals ::text[]) AS q(key, val)
+                    JOIN {table} c ON c.ein = q.val
+                )"""
+            )
+            unions.append("SELECT key, ein, rank, signal FROM ein_hits")
+
+        if arm == "nonprofit" and has_domain:
+            # Exact-domain is a hash join — ONE scan for the whole batch.
+            ctes.append(
+                f"""url_hits AS (
+                    SELECT q.key, c.ein, {IDENTITY_RANK_URL_EXACT}::float8 AS rank,
+                           'url_exact' AS signal
+                    FROM unnest(:url_keys ::text[], :url_vals ::text[]) AS q(key, val)
+                    JOIN public.nonprofit_canonical c ON c.domain = q.val
+                    WHERE c.domain <> ''
+                )"""
+            )
+            unions.append("SELECT key, ein, rank, signal FROM url_hits")
+            if include_url_prefix:
+                # Opt-in: LIKE 'x%' can't use the btree under a non-C
+                # collation, so this degenerates to one scan per input row.
+                ctes.append(
+                    f"""url_prefix_hits AS (
+                        SELECT q.key, c.ein,
+                               {IDENTITY_RANK_URL_PREFIX}::float8 AS rank,
+                               'url_prefix' AS signal
+                        FROM unnest(:url_keys ::text[], :url_vals ::text[]) AS q(key, val)
+                        JOIN public.nonprofit_canonical c
+                          ON c.domain LIKE q.val || '%'
+                        WHERE c.domain <> ''
+                    )"""
+                )
+                unions.append("SELECT key, ein, rank, signal FROM url_prefix_hits")
+
+        join = (
+            "LEFT JOIN public.nonprofit_canonical c USING (ein)"
+            if arm == "nonprofit"
+            else "JOIN public.funder_canonical c USING (ein)"
+        )
+        cte_sql = ",\n            ".join(ctes)
+        union_sql = "\n                    UNION ALL\n                    ".join(unions)
+        # ROW_NUMBER partitioned by key applies limit_per_query server-side,
+        # so a 500-row batch can't drag back the entire match set for a
+        # generic name like "foundation".
+        rank_filter = "WHERE rn <= :limit_per_query" if limit_per_query is not None else ""
+        return f"""
+            WITH {cte_sql},
+            matched AS (
+                SELECT key, ein,
+                       MAX(rank) AS rank,
+                       (ARRAY_AGG(signal ORDER BY rank DESC))[1] AS signal
+                FROM (
+                    {union_sql}
+                ) u
+                GROUP BY key, ein
+            ),
+            ranked AS (
+                SELECT
+                    m.key,
+                    m.ein,
+                    c.name,
+                    c.name_secondary,
+                    c.city,
+                    c.state,
+                    NULLIF(c.latest_taxyear, '')::int AS latest_taxyear,
+                    m.rank,
+                    m.signal,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY m.key
+                        ORDER BY m.rank DESC,
+                                 NULLIF(c.latest_taxyear, '')::int DESC NULLS LAST,
+                                 c.name ASC,
+                                 m.ein ASC
+                    ) AS rn
+                FROM matched m
+                {join}
+            )
+            SELECT key, ein, name, name_secondary, city, state,
+                   latest_taxyear, rank, signal
+            FROM ranked
+            {rank_filter}
+        """
+
+    def search_identity_bulk(
+        self,
+        queries: Sequence[IdentityQuery],
+        *,
+        org_type: IdentityOrgType = "all",
+        include_narrative: bool = True,
+        include_url_prefix: bool = False,
+        limit_per_query: int | None = 25,
+        chunk_size: int = 500,
+        on_invalid: Literal["raise", "skip"] = "raise",
+    ) -> dict[str, list[IdentityHit]]:
+        """Batched ``search_identity`` — N input rows, not N round trips.
+
+        Returns ``{query.key: [IdentityHit, ...]}`` with an entry for **every**
+        input key, empty list included, so callers can zip results back onto
+        their rows without membership checks.
+
+        Per-signal cost is wildly uneven, and that drives how to call this:
+
+        * ``ein`` — PK index scan. ~500 lookups in one ~170ms round trip
+          against a remote instance, vs ~78s looping ``search_identity``.
+        * ``url`` (exact domain) — hash join, ONE table scan for the whole
+          batch regardless of size. ~500 in ~300ms.
+        * ``url`` prefix tier — off by default here. ``LIKE 'x%'`` can't use
+          the ``domain`` btree under a non-C collation, so it degrades to a
+          scan per input row. It's also much less useful in a pipeline than
+          in a search box: URLs arrive normalized, and prefix matching
+          invites false positives. Set ``include_url_prefix=True`` when you
+          specifically want it.
+        * ``name`` — the expensive one. ``ILIKE '%x%'`` is unindexable, so
+          this is a scan per input row no matter how it's batched (batching
+          still saves the round trips — roughly 30% — but not the scans).
+          Budget ~0.5s per named row. Above a few hundred name-only rows,
+          prefer ``iter_identity_universe`` and match in process.
+        * narrative FTS — GIN-indexed, so it stays an indexed lookup per row.
+
+        ``chunk_size`` bounds both the array-parameter size and the length of
+        any single transaction; progress is logged per chunk. Lower it for
+        name-heavy batches (a 500-name chunk is a multi-minute query), raise
+        it for pure EIN/URL work.
+
+        ``on_invalid`` controls malformed ``ein``/``url`` values. ``"raise"``
+        (default) matches ``search_identity`` and fails the whole batch, with
+        every offending key named — validation runs before any query, so a bad
+        row costs no query time. ``"skip"`` drops just the bad signal and
+        keeps the row (a row left with no usable signal gets an empty list);
+        use it when feeding unwashed customer data where ``"N/A"`` in a URL
+        column shouldn't sink 5,000 good rows.
+
+        ``org_type``, ``include_narrative``, and the ranking tiers behave
+        exactly as in ``search_identity``.
+        """
+        if org_type not in ("all", "nonprofit", "funder"):
+            raise ValueError(
+                f"org_type must be 'all', 'nonprofit', or 'funder', got {org_type!r}"
+            )
+        if on_invalid not in ("raise", "skip"):
+            raise ValueError(
+                f"on_invalid must be 'raise' or 'skip', got {on_invalid!r}"
+            )
+        if chunk_size < 1:
+            raise ValueError(f"chunk_size must be >= 1, got {chunk_size}")
+        if not queries:
+            return {}
+
+        seen: set[str] = set()
+        for q in queries:
+            if not q.key:
+                raise ValueError("IdentityQuery.key must be a non-empty string")
+            if q.key in seen:
+                raise ValueError(f"duplicate IdentityQuery.key: {q.key!r}")
+            seen.add(q.key)
+
+        # Validate + normalize everything up front so a malformed row on
+        # input 4,000 doesn't surface after twenty minutes of scanning.
+        normalized: list[tuple[str, str | None, str, str]] = []
+        invalid: list[str] = []
+        for q in queries:
+            try:
+                name, domain, ein_digits = _normalize_identity_signals(
+                    q.name, q.url, q.ein, strict=(on_invalid == "raise")
+                )
+            except ValueError as exc:
+                invalid.append(f"{q.key}: {exc}")
+                continue
+            normalized.append((q.key, name, domain, ein_digits))
+        if invalid:
+            shown = "; ".join(invalid[:10])
+            more = f" (+{len(invalid) - 10} more)" if len(invalid) > 10 else ""
+            raise ValueError(f"invalid identity queries -> {shown}{more}")
+
+        results: dict[str, list[IdentityHit]] = {q.key: [] for q in queries}
+        run_nonprofit = org_type in ("all", "nonprofit")
+        run_funder = org_type in ("all", "funder")
+
+        total_chunks = (len(normalized) + chunk_size - 1) // chunk_size
+        logger.info(
+            "search_identity_bulk: %d queries in %d chunk(s) of %d, org_type=%s, "
+            "include_narrative=%s, include_url_prefix=%s, limit_per_query=%s",
+            len(normalized),
+            total_chunks,
+            chunk_size,
+            org_type,
+            include_narrative,
+            include_url_prefix,
+            limit_per_query,
+        )
+
+        with self._session() as session:
+            for chunk_i in range(total_chunks):
+                chunk = normalized[chunk_i * chunk_size : (chunk_i + 1) * chunk_size]
+
+                name_keys, name_vals = [], []
+                url_keys, url_vals = [], []
+                ein_keys, ein_vals = [], []
+                for key, name, domain, ein_digits in chunk:
+                    if name is not None:
+                        name_keys.append(key)
+                        name_vals.append(name)
+                    if domain:
+                        url_keys.append(key)
+                        url_vals.append(domain)
+                    if ein_digits:
+                        ein_keys.append(key)
+                        ein_vals.append(ein_digits)
+
+                has_name, has_domain, has_ein = (
+                    bool(name_keys),
+                    bool(url_keys),
+                    bool(ein_keys),
+                )
+                if not (has_name or has_domain or has_ein):
+                    continue
+
+                base_params: dict[str, object] = {
+                    "name_keys": name_keys,
+                    "name_vals": name_vals,
+                    "fts_keys": name_keys,
+                    "fts_vals": name_vals,
+                    "url_keys": url_keys,
+                    "url_vals": url_vals,
+                    "ein_keys": ein_keys,
+                    "ein_vals": ein_vals,
+                }
+                if limit_per_query is not None:
+                    base_params["limit_per_query"] = limit_per_query
+
+                for arm, run in (("nonprofit", run_nonprofit), ("funder", run_funder)):
+                    # The funder arm has no URL or narrative surface, so a
+                    # chunk carrying only URLs gives it nothing to match.
+                    if not run:
+                        continue
+                    if arm == "funder" and not (has_name or has_ein):
+                        continue
+                    sql = self._identity_bulk_arm_sql(
+                        arm=arm,
+                        has_name=has_name,
+                        has_domain=has_domain,
+                        has_ein=has_ein,
+                        include_narrative=include_narrative,
+                        include_url_prefix=include_url_prefix,
+                        limit_per_query=limit_per_query,
+                    )
+                    rows = session.execute(text(sql), base_params).mappings().all()
+                    for r in rows:
+                        results[r["key"]].append(
+                            IdentityHit(
+                                ein=r["ein"],
+                                name=r["name"],
+                                name_secondary=r["name_secondary"],
+                                city=r["city"],
+                                state=r["state"],
+                                latest_taxyear=(
+                                    int(r["latest_taxyear"])
+                                    if r["latest_taxyear"] is not None
+                                    else None
+                                ),
+                                org_type=arm,
+                                rank=float(r["rank"]),
+                                signal=r["signal"],
+                            )
+                        )
+                logger.info(
+                    "search_identity_bulk: chunk %d/%d done (%d rows)",
+                    chunk_i + 1,
+                    total_chunks,
+                    len(chunk),
+                )
+
+        # Cross-arm merge per key, then the per-key slice (SQL already
+        # limited each arm; this trims the union of the two).
+        for key, hits in results.items():
+            hits.sort(key=_identity_sort_key)
+            if limit_per_query is not None and len(hits) > limit_per_query:
+                results[key] = hits[:limit_per_query]
+
+        matched = sum(1 for h in results.values() if h)
+        logger.info(
+            "search_identity_bulk: %d/%d queries matched", matched, len(results)
+        )
+        return results
+
+    def iter_identity_universe(
+        self,
+        *,
+        org_type: IdentityOrgType = "all",
+        batch_size: int = 10_000,
+    ) -> Iterator[CanonicalIdentity]:
+        """Stream the full canonical identity universe for local matching.
+
+        The escape hatch for name-heavy resolution. Name search can't be made
+        cheap server-side — ``ILIKE '%x%'`` is unindexable, so every name
+        costs a full scan whether looped or batched (measured: ~0.55s per
+        name either way) — but the whole universe is small enough to pull
+        once: ~479K nonprofit rows stream in ~25s at ~19K rows/s, ~57MB of
+        strings, plus ~161K funder rows. That's break-even at roughly 50
+        name-only rows and a rout past a few hundred.
+
+        Yields ``CanonicalIdentity`` and streams server-side (no full
+        materialization in the driver), so memory stays bounded by
+        ``batch_size`` rather than by the table.
+
+        Matching itself deliberately stays out of this client: it needs
+        pandas/recordlinkage, and the client is dependency-light by design
+        (sqlalchemy + psycopg2 only) so consumers can install it standalone.
+        ``grant_matching.py`` already has the blocking + Jaro-Winkler pattern
+        to feed this into — it's the same shape as the 990-PF matching work.
+        """
+        if org_type not in ("all", "nonprofit", "funder"):
+            raise ValueError(
+                f"org_type must be 'all', 'nonprofit', or 'funder', got {org_type!r}"
+            )
+        if batch_size < 1:
+            raise ValueError(f"batch_size must be >= 1, got {batch_size}")
+
+        # funder_canonical has no website (hence no generated domain column)
+        # and no DBA columns; NULL them so both arms yield the same shape.
+        arms: list[tuple[str, str]] = []
+        if org_type in ("all", "nonprofit"):
+            arms.append(("nonprofit", """
+                SELECT ein, name, name_secondary, dba_1, dba_2, domain,
+                       city, state, NULLIF(latest_taxyear, '')::int AS latest_taxyear
+                FROM public.nonprofit_canonical
+            """))
+        if org_type in ("all", "funder"):
+            arms.append(("funder", """
+                SELECT ein, name, name_secondary,
+                       NULL::text AS dba_1, NULL::text AS dba_2, NULL::text AS domain,
+                       city, state, NULLIF(latest_taxyear, '')::int AS latest_taxyear
+                FROM public.funder_canonical
+            """))
+
+        logger.info(
+            "iter_identity_universe: streaming org_type=%s, batch_size=%d",
+            org_type,
+            batch_size,
+        )
+        for arm, sql in arms:
+            emitted = 0
+            with self._session() as session:
+                result = (
+                    session.connection()
+                    .execution_options(stream_results=True, yield_per=batch_size)
+                    .execute(text(sql))
+                    .mappings()
+                )
+                for r in result:
+                    emitted += 1
+                    yield CanonicalIdentity(
+                        ein=r["ein"],
+                        name=r["name"],
+                        name_secondary=r["name_secondary"],
+                        dba_1=r["dba_1"],
+                        dba_2=r["dba_2"],
+                        domain=r["domain"],
+                        city=r["city"],
+                        state=r["state"],
+                        latest_taxyear=(
+                            int(r["latest_taxyear"])
+                            if r["latest_taxyear"] is not None
+                            else None
+                        ),
+                        org_type=arm,
+                    )
+            logger.info("iter_identity_universe: %s arm streamed %d rows", arm, emitted)
 
     def get_nonprofit(self, ein: str) -> Nonprofit | None:
         sql = """

--- a/givingtuesday_datamart/client/client.py
+++ b/givingtuesday_datamart/client/client.py
@@ -588,17 +588,12 @@ class GtDatamartClient:
             params["domain"] = domain
             params["domain_prefix"] = f"{domain}%"
 
-        # Every remaining signal source selects from the canonical itself, so
-        # this LEFT JOIN is now provably equivalent to an inner one — it can
-        # no longer surface the 990-EZ filers (present in nonprofit_text,
-        # absent from nonprofit_canonical) that the dropped narrative arm
-        # used to reach. Kept as LEFT so adding a nonprofit_text-sourced
-        # signal later doesn't silently start dropping rows.
-        join = (
-            "LEFT JOIN public.nonprofit_canonical c USING (ein)"
-            if arm == "nonprofit"
-            else "JOIN public.funder_canonical c USING (ein)"
-        )
+        # Inner join: every signal source above selects from this same table,
+        # so the matched EIN set is a subset of it by construction. (A LEFT
+        # JOIN would be needed only for a signal sourced from nonprofit_text,
+        # which can carry 990-EZ filers absent from the canonical — there is
+        # no such signal here.)
+        join = f"JOIN {table} c USING (ein)"
         cte_sql = ",\n            ".join(ctes)
         union_sql = "\n                    UNION ALL\n                    ".join(unions)
         # MAX(rank) picks the winning tier per EIN; ARRAY_AGG ordered by
@@ -845,13 +840,8 @@ class GtDatamartClient:
                 )
                 unions.append("SELECT key, ein, rank, signal FROM url_prefix_hits")
 
-        # LEFT for the same defensive reason as the single-row path — every
-        # current source selects from the canonical, so it can't yield NULLs.
-        join = (
-            "LEFT JOIN public.nonprofit_canonical c USING (ein)"
-            if arm == "nonprofit"
-            else "JOIN public.funder_canonical c USING (ein)"
-        )
+        # Inner, for the same reason as the single-row path.
+        join = f"JOIN {table} c USING (ein)"
         cte_sql = ",\n            ".join(ctes)
         union_sql = "\n                    UNION ALL\n                    ".join(unions)
         # ROW_NUMBER partitioned by key applies limit_per_query server-side,

--- a/givingtuesday_datamart/client/client.py
+++ b/givingtuesday_datamart/client/client.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from contextlib import contextmanager
 from typing import Iterator, Literal
 
@@ -26,6 +27,7 @@ from givingtuesday_datamart.client.models import (
     BasicFieldsRow,
     Grant,
     GrantSummary,
+    IdentityHit,
     Nonprofit,
     NonprofitHit,
 )
@@ -35,6 +37,17 @@ logger = logging.getLogger(__name__)
 
 GranteeOrGranter = Literal["grantee", "granter"]
 SearchMode = Literal["stemmed", "exact"]
+IdentityOrgType = Literal["all", "nonprofit", "funder"]
+
+# Ranking tiers for ``search_identity``, ported verbatim from the frontend's
+# ``searchOrgs`` query (frontend/src/lib/queries/search.ts). Tiers are
+# separated by wide ranges so a tier always beats every lower tier; narrative
+# FTS uses raw ``ts_rank_cd`` scores (typically 0–~50), which always sort
+# below the fixed tiers.
+IDENTITY_RANK_EIN = 2_000_000.0
+IDENTITY_RANK_URL_EXACT = 1_500_000.0
+IDENTITY_RANK_URL_PREFIX = 1_200_000.0
+IDENTITY_RANK_NAME = 1_000_000.0
 
 DEFAULT_DATABASE = "gt_datamart"
 DEFAULT_PORT = 5432
@@ -85,6 +98,24 @@ def _engine_from_components(
         database=database,
     )
     return create_engine(url, future=True)
+
+
+def _normalize_domain(raw: str) -> str:
+    """Port of the frontend's ``normalizeDomainForQuery`` (validation.ts).
+
+    Must stay consistent with the SQL expression behind the generated
+    ``nonprofit_canonical.domain`` column (canonical/build.py): lowercase,
+    scheme + ``www.`` stripped, path/query/fragment dropped. Returns ``""``
+    when the input isn't domain-shaped (contains whitespace after stripping,
+    or is shorter than 3 chars).
+    """
+    stripped = raw.strip().lower()
+    stripped = re.sub(r"^(https?:)?//", "", stripped)
+    stripped = re.sub(r"^www\.", "", stripped)
+    stripped = re.sub(r"[/?#].*$", "", stripped)
+    if re.search(r"\s", stripped) or len(stripped) < 3:
+        return ""
+    return stripped
 
 
 class GtDatamartClient:
@@ -426,6 +457,292 @@ class GtDatamartClient:
             for r in rows
         ]
         logger.info("get_nonprofits_by_ein: %d hits", len(hits))
+        return hits
+
+    def _identity_arm_sql(
+        self,
+        *,
+        arm: Literal["nonprofit", "funder"],
+        name: str | None,
+        domain: str,
+        ein_digits: str,
+        include_narrative: bool,
+        limit: int | None,
+    ) -> tuple[str, dict[str, object]]:
+        """Assemble one arm of the ``search_identity`` query.
+
+        CTE union of the active signal sources, collapsed to one row per EIN
+        with the best rank and the signal that produced it. Signals that
+        weren't supplied are simply not emitted (the frontend gates its URL
+        CTE the same way — ``domain`` is a generated column that may not
+        exist on older canonical builds, so it must only be referenced when
+        actually searching by URL).
+        """
+        table = (
+            "public.nonprofit_canonical" if arm == "nonprofit" else "public.funder_canonical"
+        )
+        ctes: list[str] = []
+        unions: list[str] = []
+        params: dict[str, object] = {}
+
+        if name is not None:
+            # Funders carry no DBA columns; nonprofits match on all four
+            # name surfaces. ``%`` / ``_`` in the input are live ILIKE
+            # wildcards — parity with the frontend, which doesn't escape.
+            name_cols = (
+                ["name", "name_secondary", "dba_1", "dba_2"]
+                if arm == "nonprofit"
+                else ["name", "name_secondary"]
+            )
+            name_where = " OR ".join(f"{col} ILIKE :like" for col in name_cols)
+            ctes.append(
+                f"""name_hits AS (
+                    SELECT ein, {IDENTITY_RANK_NAME}::float8 AS rank, 'name' AS signal
+                    FROM {table}
+                    WHERE {name_where}
+                )"""
+            )
+            unions.append("SELECT ein, rank, signal FROM name_hits")
+            params["like"] = f"%{name}%"
+
+        if arm == "nonprofit" and name is not None and include_narrative:
+            ctes.append(
+                """fts_hits AS (
+                    SELECT nt.ein,
+                           ts_rank_cd(nt.text_tsv_compact, q)::float8 AS rank,
+                           'narrative' AS signal
+                    FROM public.nonprofit_text nt,
+                         websearch_to_tsquery('english', :raw_name) AS q
+                    WHERE nt.text_tsv_compact @@ q
+                )"""
+            )
+            unions.append("SELECT ein, rank, signal FROM fts_hits")
+            params["raw_name"] = name
+
+        if ein_digits:
+            ctes.append(
+                f"""ein_hits AS (
+                    SELECT ein, {IDENTITY_RANK_EIN}::float8 AS rank, 'ein' AS signal
+                    FROM {table}
+                    WHERE ein = :ein
+                )"""
+            )
+            unions.append("SELECT ein, rank, signal FROM ein_hits")
+            params["ein"] = ein_digits
+
+        if arm == "nonprofit" and domain:
+            # Both URL tiers sit between EIN-exact and name. Uses the
+            # ix_nonprofit_canonical_domain partial btree (LIKE 'foo%' is
+            # index-eligible on a btree).
+            ctes.append(
+                f"""url_hits AS (
+                    SELECT ein,
+                           CASE WHEN domain = :domain
+                                THEN {IDENTITY_RANK_URL_EXACT}::float8
+                                ELSE {IDENTITY_RANK_URL_PREFIX}::float8 END AS rank,
+                           CASE WHEN domain = :domain
+                                THEN 'url_exact' ELSE 'url_prefix' END AS signal
+                    FROM public.nonprofit_canonical
+                    WHERE domain = :domain OR domain LIKE :domain_prefix
+                )"""
+            )
+            unions.append("SELECT ein, rank, signal FROM url_hits")
+            params["domain"] = domain
+            params["domain_prefix"] = f"{domain}%"
+
+        # LEFT JOIN on the nonprofit arm because narrative hits can be
+        # 990-EZ filers absent from nonprofit_canonical — they come back
+        # with NULL identity columns (same contract as search_nonprofits).
+        # The funder arm's sources are all funder_canonical itself, so its
+        # join is definitionally inner.
+        join = (
+            "LEFT JOIN public.nonprofit_canonical c USING (ein)"
+            if arm == "nonprofit"
+            else "JOIN public.funder_canonical c USING (ein)"
+        )
+        cte_sql = ",\n            ".join(ctes)
+        union_sql = "\n                    UNION ALL\n                    ".join(unions)
+        # MAX(rank) picks the winning tier per EIN; ARRAY_AGG ordered by
+        # rank DESC reports which signal that winning rank came from.
+        sql = f"""
+            WITH {cte_sql},
+            matched AS (
+                SELECT ein,
+                       MAX(rank) AS rank,
+                       (ARRAY_AGG(signal ORDER BY rank DESC))[1] AS signal
+                FROM (
+                    {union_sql}
+                ) u
+                GROUP BY ein
+            )
+            SELECT
+                m.ein,
+                c.name,
+                c.name_secondary,
+                c.city,
+                c.state,
+                NULLIF(c.latest_taxyear, '')::int AS latest_taxyear,
+                m.rank,
+                m.signal
+            FROM matched m
+            {join}
+            ORDER BY m.rank DESC,
+                     NULLIF(c.latest_taxyear, '')::int DESC NULLS LAST,
+                     c.name ASC,
+                     m.ein ASC
+        """
+        if limit is not None:
+            sql += " LIMIT :limit"
+            params["limit"] = limit
+        return sql, params
+
+    def search_identity(
+        self,
+        name: str | None = None,
+        url: str | None = None,
+        ein: str | None = None,
+        *,
+        org_type: IdentityOrgType = "all",
+        include_narrative: bool = True,
+        limit: int | None = 25,
+    ) -> list[IdentityHit]:
+        """Multi-signal ranked identity search, ported from the frontend's
+        ``searchOrgs`` query (frontend/src/lib/queries/search.ts).
+
+        Built for EIN-less nonprofit resolution: pass whatever identity
+        signals a row has and get back ranked candidates. Signals are
+        inferred from the arguments — at least one of ``name`` / ``url`` /
+        ``ein`` is required:
+
+        * ``ein`` — exact match (rank 2,000,000). Separators are stripped
+          (``"13-1234567"`` works); raises ``ValueError`` unless exactly 9
+          digits remain.
+        * ``url`` — normalized to a bare domain (scheme, ``www.``, and
+          path/query/fragment stripped) and matched against the generated
+          ``nonprofit_canonical.domain`` column: exact domain (1,500,000)
+          beats prefix domain (1,200,000). Raises ``ValueError`` when the
+          input doesn't normalize to something domain-shaped — normalize
+          upstream, don't pass raw customer junk like ``"N/A"``.
+        * ``name`` — ILIKE substring over ``name`` / ``name_secondary``
+          (plus ``dba_1`` / ``dba_2`` on the nonprofit arm) at rank
+          1,000,000, UNIONed with narrative FTS over
+          ``nonprofit_text.text_tsv_compact`` via
+          ``websearch_to_tsquery('english', ...)`` ranked by raw
+          ``ts_rank_cd`` (typically 0–~50, always below the fixed tiers).
+          Set ``include_narrative=False`` to search names only.
+
+        Two arms, mirroring the frontend: ``nonprofit_canonical`` (all
+        signals) and ``funder_canonical`` (name + EIN only — funders have no
+        URL or narrative surface yet). ``org_type`` restricts to one arm;
+        a funder-only search with just a ``url`` has nothing to match and
+        returns ``[]``. Each EIN collapses to its best rank per arm, with
+        ``IdentityHit.signal`` naming the winning signal.
+
+        The nonprofit arm LEFT JOINs ``nonprofit_canonical``, so ~46K 990-EZ
+        filers reachable only through the narrative signal return with NULL
+        identity columns (same contract as ``search_nonprofits``).
+
+        ``limit`` is pushed into each arm's SQL, then the arms are merged
+        and re-sliced here (rank DESC, latest_taxyear DESC nulls-last, name,
+        ein — the frontend's exact ordering), so worst case ``2 * limit``
+        rows cross the wire. ``limit=None`` returns everything; fine for
+        EIN/URL lookups, unbounded for broad name/narrative queries.
+        """
+        if org_type not in ("all", "nonprofit", "funder"):
+            raise ValueError(
+                f"org_type must be 'all', 'nonprofit', or 'funder', got {org_type!r}"
+            )
+
+        name = name.strip() if name is not None and name.strip() else None
+
+        ein_digits = ""
+        if ein is not None:
+            ein_digits = re.sub(r"\D", "", ein)
+            if len(ein_digits) != 9:
+                raise ValueError(
+                    f"ein must contain exactly 9 digits, got {ein!r}"
+                )
+
+        domain = ""
+        if url is not None:
+            domain = _normalize_domain(url)
+            if not domain:
+                raise ValueError(
+                    f"url does not normalize to a searchable domain: {url!r}"
+                )
+
+        if name is None and not ein_digits and not domain:
+            raise ValueError(
+                "search_identity requires at least one of name, url, or ein"
+            )
+
+        run_nonprofit = org_type in ("all", "nonprofit")
+        # The funder arm can only contribute via name or EIN; skip the
+        # query entirely when neither is present (mirrors the frontend's
+        # foundationCanContribute gate).
+        run_funder = org_type in ("all", "funder") and (name is not None or bool(ein_digits))
+        if not run_nonprofit and not run_funder:
+            logger.warning(
+                "search_identity: funder arm has no URL signal; nothing to search"
+            )
+            return []
+
+        logger.info(
+            "search_identity: signals(name=%s, url=%s, ein=%s), org_type=%s, "
+            "include_narrative=%s, limit=%s",
+            name is not None,
+            bool(domain),
+            bool(ein_digits),
+            org_type,
+            include_narrative,
+            limit,
+        )
+
+        hits: list[IdentityHit] = []
+        with self._session() as session:
+            for arm, run in (("nonprofit", run_nonprofit), ("funder", run_funder)):
+                if not run:
+                    continue
+                sql, params = self._identity_arm_sql(
+                    arm=arm,
+                    name=name,
+                    domain=domain,
+                    ein_digits=ein_digits,
+                    include_narrative=include_narrative,
+                    limit=limit,
+                )
+                rows = session.execute(text(sql), params).mappings().all()
+                hits.extend(
+                    IdentityHit(
+                        ein=r["ein"],
+                        name=r["name"],
+                        name_secondary=r["name_secondary"],
+                        city=r["city"],
+                        state=r["state"],
+                        latest_taxyear=(
+                            int(r["latest_taxyear"]) if r["latest_taxyear"] is not None else None
+                        ),
+                        org_type=arm,
+                        rank=float(r["rank"]),
+                        signal=r["signal"],
+                    )
+                    for r in rows
+                )
+
+        # Cross-arm merge with the frontend's exact ordering; NULL taxyears
+        # and names sort last within their rank tier.
+        hits.sort(
+            key=lambda h: (
+                -h.rank,
+                -(h.latest_taxyear if h.latest_taxyear is not None else -1),
+                h.name is None,
+                h.name or "",
+                h.ein,
+            )
+        )
+        if limit is not None:
+            hits = hits[:limit]
+        logger.info("search_identity: %d hits", len(hits))
         return hits
 
     def get_nonprofit(self, ein: str) -> Nonprofit | None:

--- a/givingtuesday_datamart/client/models.py
+++ b/givingtuesday_datamart/client/models.py
@@ -32,6 +32,35 @@ class NonprofitHit:
 
 
 @dataclass(frozen=True)
+class IdentityHit:
+    """One ranked hit from ``GtDatamartClient.search_identity``.
+
+    ``org_type`` is ``"nonprofit"`` (990 filers, ``nonprofit_canonical``) or
+    ``"funder"`` (990-PF filers, ``funder_canonical``) depending on which
+    search arm produced the hit.
+
+    ``signal`` names the strongest signal that matched for this EIN:
+    ``"ein"`` > ``"url_exact"`` > ``"url_prefix"`` > ``"name"`` >
+    ``"narrative"``. ``rank`` is the numeric tier behind that ordering
+    (fixed constants for the first four; raw ``ts_rank_cd`` for narrative).
+
+    Identity columns are NULL for ~46K 990-EZ filers that exist in
+    ``nonprofit_text`` but not ``nonprofit_canonical`` — those can only
+    arrive via the narrative signal.
+    """
+
+    ein: str
+    name: str | None
+    name_secondary: str | None
+    city: str | None
+    state: str | None
+    latest_taxyear: int | None
+    org_type: str
+    rank: float
+    signal: str
+
+
+@dataclass(frozen=True)
 class Nonprofit:
     """One row from ``public.nonprofit_canonical`` (DISTINCT ON winner per
     EIN, latest taxyear → taxperend → ingested_at), enriched with

--- a/givingtuesday_datamart/client/models.py
+++ b/givingtuesday_datamart/client/models.py
@@ -40,13 +40,14 @@ class IdentityHit:
     search arm produced the hit.
 
     ``signal`` names the strongest signal that matched for this EIN:
-    ``"ein"`` > ``"url_exact"`` > ``"url_prefix"`` > ``"name"`` >
-    ``"narrative"``. ``rank`` is the numeric tier behind that ordering
-    (fixed constants for the first four; raw ``ts_rank_cd`` for narrative).
+    ``"ein"`` > ``"url_exact"`` > ``"url_prefix"`` > ``"name"``. ``rank`` is
+    the fixed numeric tier behind that ordering.
 
-    Identity columns are NULL for ~46K 990-EZ filers that exist in
-    ``nonprofit_text`` but not ``nonprofit_canonical`` — those can only
-    arrive via the narrative signal.
+    All four signals are identity evidence, which is what makes ``signal``
+    usable as an auto-accept gate (``"ein"`` and ``"url_exact"`` are
+    effectively exact matches; ``"name"`` is a substring hit that still needs
+    a similarity check). Narrative/topical matching is deliberately not part
+    of this type — see ``GtDatamartClient.search_identity``.
     """
 
     ein: str

--- a/givingtuesday_datamart/client/models.py
+++ b/givingtuesday_datamart/client/models.py
@@ -61,6 +61,48 @@ class IdentityHit:
 
 
 @dataclass(frozen=True)
+class IdentityQuery:
+    """One row of input to ``GtDatamartClient.search_identity_bulk``.
+
+    ``key`` is the caller's own row identifier (portfolio row id, source
+    system id, whatever). It's echoed back as the result-dict key and never
+    interpreted — it exists so callers don't have to reconstruct which hit
+    belongs to which input row. Keys must be unique within a batch.
+
+    The signal fields carry the same semantics (and the same normalization
+    and validation) as the corresponding ``search_identity`` arguments.
+    """
+
+    key: str
+    name: str | None = None
+    url: str | None = None
+    ein: str | None = None
+
+
+@dataclass(frozen=True)
+class CanonicalIdentity:
+    """One identity row streamed by ``GtDatamartClient.iter_identity_universe``.
+
+    The local-matching escape hatch: name matching can't be pushed into
+    Postgres efficiently (``ILIKE '%x%'`` is unindexable, so every name is a
+    full scan), so name-heavy workloads pull the universe once and match in
+    process. Deliberately not a ``IdentityHit`` — there's no rank or signal,
+    because nothing has been matched yet.
+    """
+
+    ein: str
+    name: str | None
+    name_secondary: str | None
+    dba_1: str | None
+    dba_2: str | None
+    domain: str | None
+    city: str | None
+    state: str | None
+    latest_taxyear: int | None
+    org_type: str
+
+
+@dataclass(frozen=True)
 class Nonprofit:
     """One row from ``public.nonprofit_canonical`` (DISTINCT ON winner per
     EIN, latest taxyear → taxperend → ingested_at), enriched with

--- a/tests/test_client_identity_bulk.py
+++ b/tests/test_client_identity_bulk.py
@@ -239,16 +239,24 @@ def test_url_prefix_tier_is_opt_in():
     assert "1200000.0::float8" in sql
 
 
-def test_narrative_can_be_disabled():
+def test_narrative_arm_is_never_emitted():
     client, session = _client([[]])
     client.search_identity_bulk(
-        [IdentityQuery(key="a", name="x")],
-        org_type="nonprofit",
-        include_narrative=False,
+        [IdentityQuery(key="a", name="x")], org_type="nonprofit"
     )
-    sql, _ = session.calls[0]
+    sql, params = session.calls[0]
     assert "fts_hits" not in sql
     assert "nonprofit_text" not in sql
+    assert "websearch_to_tsquery" not in sql
+    assert "fts_keys" not in params
+
+
+def test_include_narrative_kwarg_is_gone():
+    client, _ = _client()
+    with pytest.raises(TypeError):
+        client.search_identity_bulk(
+            [IdentityQuery(key="a", name="x")], include_narrative=True
+        )
 
 
 def test_funder_arm_skipped_when_chunk_has_only_urls():
@@ -285,7 +293,7 @@ def test_limit_none_omits_row_number_filter():
 def test_hits_grouped_by_key_and_ordered_within_key():
     nonprofit_rows = [
         _row("a", "100000001", rank=1_000_000.0, latest_taxyear=2020),
-        _row("a", "100000002", rank=12.5, signal="narrative"),
+        _row("a", "100000002", rank=1_200_000.0, signal="url_prefix"),
         _row("b", "100000003", rank=1_000_000.0),
     ]
     funder_rows = [
@@ -295,7 +303,7 @@ def test_hits_grouped_by_key_and_ordered_within_key():
     out = client.search_identity_bulk(
         [IdentityQuery(key="a", name="x", ein="131234567"), IdentityQuery(key="b", name="y")]
     )
-    assert [h.ein for h in out["a"]] == ["200000001", "100000001", "100000002"]
+    assert [h.ein for h in out["a"]] == ["200000001", "100000002", "100000001"]
     assert [h.org_type for h in out["a"]] == ["funder", "nonprofit", "nonprofit"]
     assert [h.ein for h in out["b"]] == ["100000003"]
 
@@ -315,14 +323,14 @@ def test_limit_reapplied_after_cross_arm_merge():
 
 def test_null_identity_columns_preserved():
     rows = [_row("a", "100000009", name=None, city=None, state=None,
-                 latest_taxyear=None, rank=3.2, signal="narrative")]
+                 latest_taxyear=None, rank=1_000_000.0)]
     client, _ = _client([rows])
     out = client.search_identity_bulk(
         [IdentityQuery(key="a", name="tutoring")], org_type="nonprofit"
     )
     assert out["a"][0].name is None
     assert out["a"][0].latest_taxyear is None
-    assert out["a"][0].signal == "narrative"
+    assert out["a"][0].signal == "name"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_client_identity_bulk.py
+++ b/tests/test_client_identity_bulk.py
@@ -1,0 +1,387 @@
+"""
+Unit tests for ``GtDatamartClient.search_identity_bulk`` and
+``iter_identity_universe``.
+
+Same approach as ``test_client_identity_search.py``: the SQL is
+Postgres-specific, so these cover what the client owns — batching and
+chunking, key handling, the ``on_invalid`` contract, conditional CTE
+assembly, and the per-key merge/limit. Live SQL behavior is verified
+separately against the database.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+
+from givingtuesday_datamart.client import (
+    CanonicalIdentity,
+    GtDatamartClient,
+    IdentityQuery,
+)
+
+
+class _FakeResult:
+    def __init__(self, rows: list[dict]) -> None:
+        self._rows = rows
+
+    def mappings(self) -> "_FakeResult":
+        return self
+
+    def all(self) -> list[dict]:
+        return self._rows
+
+    def __iter__(self):
+        return iter(self._rows)
+
+
+class _FakeConnection:
+    def __init__(self, session: "_FakeSession") -> None:
+        self._session = session
+
+    def execution_options(self, **kw) -> "_FakeConnection":
+        self._session.execution_options.append(kw)
+        return self
+
+    def execute(self, clause, params=None) -> _FakeResult:
+        return self._session.execute(clause, params)
+
+
+class _FakeSession:
+    def __init__(self, batches: list[list[dict]]) -> None:
+        self._batches = list(batches)
+        self.calls: list[tuple[str, dict]] = []
+        self.execution_options: list[dict] = []
+
+    def execute(self, clause, params=None) -> _FakeResult:
+        self.calls.append((clause.text, params or {}))
+        return _FakeResult(self._batches.pop(0) if self._batches else [])
+
+    def connection(self) -> _FakeConnection:
+        return _FakeConnection(self)
+
+    def close(self) -> None:
+        pass
+
+
+def _client(batches: list[list[dict]] | None = None):
+    client = GtDatamartClient(engine=create_engine("sqlite://"))
+    session = _FakeSession(batches or [])
+    client._sessionmaker = lambda: session
+    return client, session
+
+
+def _row(key: str, ein: str, **overrides) -> dict:
+    row = {
+        "key": key,
+        "ein": ein,
+        "name": f"Org {ein}",
+        "name_secondary": None,
+        "city": "Oakland",
+        "state": "CA",
+        "latest_taxyear": 2023,
+        "rank": 1_000_000.0,
+        "signal": "name",
+    }
+    row.update(overrides)
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Contract basics
+# ---------------------------------------------------------------------------
+
+
+def test_empty_input_returns_empty_dict():
+    client, session = _client()
+    assert client.search_identity_bulk([]) == {}
+    assert session.calls == []
+
+
+def test_every_key_present_even_with_no_hits():
+    client, _ = _client([[], []])
+    out = client.search_identity_bulk(
+        [IdentityQuery(key="a", name="x"), IdentityQuery(key="b", name="y")]
+    )
+    assert out == {"a": [], "b": []}
+
+
+def test_duplicate_keys_rejected():
+    client, _ = _client()
+    with pytest.raises(ValueError, match="duplicate IdentityQuery.key"):
+        client.search_identity_bulk(
+            [IdentityQuery(key="a", name="x"), IdentityQuery(key="a", name="y")]
+        )
+
+
+def test_empty_key_rejected():
+    client, _ = _client()
+    with pytest.raises(ValueError, match="non-empty string"):
+        client.search_identity_bulk([IdentityQuery(key="", name="x")])
+
+
+def test_bad_chunk_size_rejected():
+    client, _ = _client()
+    with pytest.raises(ValueError, match="chunk_size"):
+        client.search_identity_bulk([IdentityQuery(key="a", name="x")], chunk_size=0)
+
+
+# ---------------------------------------------------------------------------
+# on_invalid contract
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_raises_before_any_query_runs():
+    client, session = _client()
+    with pytest.raises(ValueError, match="invalid identity queries"):
+        client.search_identity_bulk(
+            [IdentityQuery(key="a", name="ok"), IdentityQuery(key="b", url="N/A")]
+        )
+    # The whole point of up-front validation: no query time wasted.
+    assert session.calls == []
+
+
+def test_invalid_error_names_offending_keys():
+    client, _ = _client()
+    with pytest.raises(ValueError) as exc:
+        client.search_identity_bulk(
+            [IdentityQuery(key="row-7", ein="12-345"), IdentityQuery(key="row-9", url="x")]
+        )
+    assert "row-7" in str(exc.value)
+    assert "row-9" in str(exc.value)
+
+
+def test_invalid_error_truncates_long_lists():
+    client, _ = _client()
+    bad = [IdentityQuery(key=f"r{i}", ein="1") for i in range(15)]
+    with pytest.raises(ValueError, match=r"\+5 more"):
+        client.search_identity_bulk(bad)
+
+
+def test_skip_drops_only_the_bad_signal():
+    client, session = _client([[], []])
+    client.search_identity_bulk(
+        [IdentityQuery(key="a", name="Good Name", url="N/A")],
+        on_invalid="skip",
+    )
+    # Name survived; the unusable url never reached the SQL.
+    _, params = session.calls[0]
+    assert params["name_vals"] == ["Good Name"]
+    assert params["url_vals"] == []
+
+
+def test_skip_leaves_signal_less_row_with_empty_result():
+    client, session = _client()
+    out = client.search_identity_bulk(
+        [IdentityQuery(key="a", url="N/A")], on_invalid="skip"
+    )
+    assert out == {"a": []}
+    assert session.calls == []  # nothing to search
+
+
+# ---------------------------------------------------------------------------
+# Batching / SQL assembly
+# ---------------------------------------------------------------------------
+
+
+def test_one_round_trip_per_arm_not_per_row():
+    rows = [IdentityQuery(key=f"k{i}", ein=f"1300000{i:02d}") for i in range(50)]
+    client, session = _client([[], []])
+    client.search_identity_bulk(rows)
+    # 50 inputs, 2 arms, 1 chunk -> 2 queries total.
+    assert len(session.calls) == 2
+    for _, params in session.calls:
+        assert len(params["ein_vals"]) == 50
+
+
+def test_signals_are_bound_as_parallel_key_value_arrays():
+    client, session = _client([[], []])
+    client.search_identity_bulk(
+        [
+            IdentityQuery(key="a", name="Alpha"),
+            IdentityQuery(key="b", url="https://www.beta.org/x"),
+            IdentityQuery(key="c", ein="13-4141945"),
+        ]
+    )
+    sql, params = session.calls[0]
+    assert params["name_keys"] == ["a"] and params["name_vals"] == ["Alpha"]
+    assert params["url_keys"] == ["b"] and params["url_vals"] == ["beta.org"]
+    assert params["ein_keys"] == ["c"] and params["ein_vals"] == ["134141945"]
+    assert "unnest(:name_keys ::text[], :name_vals ::text[])" in sql
+
+
+def test_chunking_splits_into_multiple_round_trips():
+    rows = [IdentityQuery(key=f"k{i}", ein=f"1300000{i:02d}") for i in range(10)]
+    client, session = _client([[] for _ in range(10)])
+    client.search_identity_bulk(rows, chunk_size=4, org_type="nonprofit")
+    # 10 rows / chunk 4 -> 3 chunks, 1 arm each.
+    assert len(session.calls) == 3
+    assert [len(p["ein_vals"]) for _, p in session.calls] == [4, 4, 2]
+
+
+def test_url_prefix_tier_is_opt_in():
+    client, session = _client([[]])
+    client.search_identity_bulk(
+        [IdentityQuery(key="a", url="example.org")], org_type="nonprofit"
+    )
+    sql, _ = session.calls[0]
+    assert "url_hits" in sql
+    assert "url_prefix_hits" not in sql
+
+    client, session = _client([[]])
+    client.search_identity_bulk(
+        [IdentityQuery(key="a", url="example.org")],
+        org_type="nonprofit",
+        include_url_prefix=True,
+    )
+    sql, _ = session.calls[0]
+    assert "url_prefix_hits" in sql
+    assert "1200000.0::float8" in sql
+
+
+def test_narrative_can_be_disabled():
+    client, session = _client([[]])
+    client.search_identity_bulk(
+        [IdentityQuery(key="a", name="x")],
+        org_type="nonprofit",
+        include_narrative=False,
+    )
+    sql, _ = session.calls[0]
+    assert "fts_hits" not in sql
+    assert "nonprofit_text" not in sql
+
+
+def test_funder_arm_skipped_when_chunk_has_only_urls():
+    client, session = _client([[]])
+    client.search_identity_bulk([IdentityQuery(key="a", url="example.org")])
+    # org_type="all", but funders have no URL surface -> nonprofit arm only.
+    assert len(session.calls) == 1
+    assert "public.funder_canonical" not in session.calls[0][0]
+
+
+def test_limit_pushed_into_sql_as_row_number_filter():
+    client, session = _client([[], []])
+    client.search_identity_bulk([IdentityQuery(key="a", name="x")], limit_per_query=5)
+    sql, params = session.calls[0]
+    assert "ROW_NUMBER() OVER (" in sql
+    assert "PARTITION BY m.key" in sql
+    assert "rn <= :limit_per_query" in sql
+    assert params["limit_per_query"] == 5
+
+
+def test_limit_none_omits_row_number_filter():
+    client, session = _client([[], []])
+    client.search_identity_bulk([IdentityQuery(key="a", name="x")], limit_per_query=None)
+    sql, params = session.calls[0]
+    assert "rn <=" not in sql
+    assert "limit_per_query" not in params
+
+
+# ---------------------------------------------------------------------------
+# Per-key merge
+# ---------------------------------------------------------------------------
+
+
+def test_hits_grouped_by_key_and_ordered_within_key():
+    nonprofit_rows = [
+        _row("a", "100000001", rank=1_000_000.0, latest_taxyear=2020),
+        _row("a", "100000002", rank=12.5, signal="narrative"),
+        _row("b", "100000003", rank=1_000_000.0),
+    ]
+    funder_rows = [
+        _row("a", "200000001", rank=2_000_000.0, signal="ein"),
+    ]
+    client, _ = _client([nonprofit_rows, funder_rows])
+    out = client.search_identity_bulk(
+        [IdentityQuery(key="a", name="x", ein="131234567"), IdentityQuery(key="b", name="y")]
+    )
+    assert [h.ein for h in out["a"]] == ["200000001", "100000001", "100000002"]
+    assert [h.org_type for h in out["a"]] == ["funder", "nonprofit", "nonprofit"]
+    assert [h.ein for h in out["b"]] == ["100000003"]
+
+
+def test_limit_reapplied_after_cross_arm_merge():
+    # Each arm independently returned `limit` rows; the union must be
+    # re-trimmed or the caller gets 2x what they asked for.
+    nonprofit_rows = [_row("a", f"10000000{i}", rank=1_000_000.0) for i in range(3)]
+    funder_rows = [_row("a", f"20000000{i}", rank=2_000_000.0) for i in range(3)]
+    client, _ = _client([nonprofit_rows, funder_rows])
+    out = client.search_identity_bulk(
+        [IdentityQuery(key="a", name="x", ein="131234567")], limit_per_query=3
+    )
+    assert len(out["a"]) == 3
+    assert all(h.org_type == "funder" for h in out["a"])
+
+
+def test_null_identity_columns_preserved():
+    rows = [_row("a", "100000009", name=None, city=None, state=None,
+                 latest_taxyear=None, rank=3.2, signal="narrative")]
+    client, _ = _client([rows])
+    out = client.search_identity_bulk(
+        [IdentityQuery(key="a", name="tutoring")], org_type="nonprofit"
+    )
+    assert out["a"][0].name is None
+    assert out["a"][0].latest_taxyear is None
+    assert out["a"][0].signal == "narrative"
+
+
+# ---------------------------------------------------------------------------
+# iter_identity_universe
+# ---------------------------------------------------------------------------
+
+
+def _universe_row(ein: str, **overrides) -> dict:
+    row = {
+        "ein": ein,
+        "name": f"Org {ein}",
+        "name_secondary": None,
+        "dba_1": None,
+        "dba_2": None,
+        "domain": "example.org",
+        "city": "Oakland",
+        "state": "CA",
+        "latest_taxyear": 2023,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_universe_streams_both_arms_tagged():
+    client, _ = _client([[_universe_row("100000001")], [_universe_row("200000001")]])
+    got = list(client.iter_identity_universe())
+    assert [r.org_type for r in got] == ["nonprofit", "funder"]
+    assert isinstance(got[0], CanonicalIdentity)
+
+
+def test_universe_respects_org_type():
+    client, session = _client([[_universe_row("100000001")]])
+    list(client.iter_identity_universe(org_type="nonprofit"))
+    assert len(session.calls) == 1
+    assert "public.nonprofit_canonical" in session.calls[0][0]
+
+
+def test_universe_uses_server_side_streaming():
+    client, session = _client([[], []])
+    list(client.iter_identity_universe(batch_size=2_500))
+    # Bounded memory is the whole point — assert the options actually get set.
+    assert session.execution_options
+    assert all(
+        o.get("stream_results") is True and o.get("yield_per") == 2_500
+        for o in session.execution_options
+    )
+
+
+def test_universe_rejects_bad_batch_size():
+    client, _ = _client()
+    with pytest.raises(ValueError, match="batch_size"):
+        list(client.iter_identity_universe(batch_size=0))
+
+
+def test_funder_arm_nulls_missing_columns():
+    # funder_canonical has no website/DBA columns; the SQL must null them so
+    # both arms yield the same dataclass shape.
+    client, session = _client([[]])
+    list(client.iter_identity_universe(org_type="funder"))
+    sql, _ = session.calls[0]
+    assert "NULL::text AS dba_1" in sql
+    assert "NULL::text AS domain" in sql

--- a/tests/test_client_identity_search.py
+++ b/tests/test_client_identity_search.py
@@ -132,12 +132,11 @@ def test_url_normalized_to_domain_and_prefix():
     assert params["domain_prefix"] == "example.org%"
 
 
-def test_name_binds_ilike_and_fts_params():
+def test_name_binds_ilike_param():
     client, session = _client()
     client.search_identity(name="Michael J Fox Foundation", org_type="nonprofit")
     (_, params), = session.calls
     assert params["like"] == "%Michael J Fox Foundation%"
-    assert params["raw_name"] == "Michael J Fox Foundation"
 
 
 # ---------------------------------------------------------------------------
@@ -151,20 +150,31 @@ def test_nonprofit_arm_emits_all_signal_ctes():
         name="fox", url="example.org", ein="131234567", org_type="nonprofit"
     )
     (sql, params), = session.calls
-    for cte in ("name_hits", "fts_hits", "ein_hits", "url_hits"):
+    for cte in ("name_hits", "ein_hits", "url_hits"):
         assert cte in sql
     # Tier constants ported from the frontend.
     assert "2000000.0::float8" in sql
     assert "1500000.0::float8" in sql
     assert "1200000.0::float8" in sql
     assert "1000000.0::float8" in sql
-    # websearch_to_tsquery + ts_rank_cd (not the plainto/ts_rank pair that
-    # search_nonprofits uses).
-    assert "websearch_to_tsquery('english'" in sql
-    assert "ts_rank_cd" in sql
-    # 990-EZ contract: narrative hits outside the canonical keep their row.
     assert "LEFT JOIN public.nonprofit_canonical" in sql
     assert params["limit"] == 25
+
+
+def test_narrative_arm_is_never_emitted():
+    # A topical text match is not identity evidence, and its raw ts_rank_cd
+    # scores would land at rank 1 whenever no real signal matches. Narrative
+    # discovery belongs to search_nonprofits.
+    client, session = _client()
+    client.search_identity(
+        name="fox", url="example.org", ein="131234567", org_type="nonprofit"
+    )
+    (sql, params), = session.calls
+    assert "fts_hits" not in sql
+    assert "nonprofit_text" not in sql
+    assert "websearch_to_tsquery" not in sql
+    assert "ts_rank_cd" not in sql
+    assert "raw_name" not in params
 
 
 def test_unused_signals_are_not_emitted():
@@ -178,13 +188,12 @@ def test_unused_signals_are_not_emitted():
     assert "domain" not in sql
 
 
-def test_include_narrative_false_drops_fts():
-    client, session = _client()
-    client.search_identity(name="fox", org_type="nonprofit", include_narrative=False)
-    (sql, _), = session.calls
-    assert "name_hits" in sql
-    assert "fts_hits" not in sql
-    assert "nonprofit_text" not in sql
+def test_include_narrative_kwarg_is_gone():
+    # Removed rather than defaulted off, so nobody can re-enable a
+    # non-identity signal without editing the client.
+    client, _ = _client()
+    with pytest.raises(TypeError):
+        client.search_identity(name="fox", include_narrative=True)
 
 
 def test_funder_arm_is_name_and_ein_only():
@@ -196,9 +205,8 @@ def test_funder_arm_is_name_and_ein_only():
     assert "public.funder_canonical" in sql
     assert "name_hits" in sql
     assert "ein_hits" in sql
-    # No URL or narrative surface, and no DBA columns, on funders.
+    # No URL surface and no DBA columns on funders.
     assert "url_hits" not in sql
-    assert "fts_hits" not in sql
     assert "dba_1" not in sql
 
 
@@ -231,7 +239,8 @@ def test_limit_none_omits_sql_limit():
 def test_merge_orders_by_rank_then_taxyear_then_name_then_ein():
     nonprofit_rows = [
         _row("100000001", rank=1_000_000.0, latest_taxyear=2020, name="Alpha"),
-        _row("100000002", rank=12.5, latest_taxyear=2023, name="Narrative Hit", signal="narrative"),
+        _row("100000002", rank=1_200_000.0, latest_taxyear=2023,
+             name="Prefix Hit", signal="url_prefix"),
     ]
     funder_rows = [
         _row("200000001", rank=2_000_000.0, latest_taxyear=2019, name="EIN Winner", signal="ein"),
@@ -242,13 +251,13 @@ def test_merge_orders_by_rank_then_taxyear_then_name_then_ein():
 
     assert [h.ein for h in hits] == [
         "200000001",  # EIN tier beats everything despite oldest taxyear
-        "100000001",  # rank tie with 200000002, same year, same name → ein ASC
+        "100000002",  # url_prefix tier outranks both name-tier rows
+        "100000001",  # rank tie with 200000002, same year, same name -> ein ASC
         "200000002",
-        "100000002",  # raw FTS rank sorts below all fixed tiers
     ]
-    assert [h.org_type for h in hits] == ["funder", "nonprofit", "funder", "nonprofit"]
+    assert [h.org_type for h in hits] == ["funder", "nonprofit", "nonprofit", "funder"]
     assert hits[0].signal == "ein"
-    assert hits[3].signal == "narrative"
+    assert hits[1].signal == "url_prefix"
 
 
 def test_none_taxyear_sorts_last_within_tier():
@@ -271,7 +280,11 @@ def test_limit_applied_after_merge():
     assert [h.org_type for h in hits] == ["funder", "funder", "funder", "nonprofit"]
 
 
-def test_990ez_null_identity_columns_survive():
+def test_null_identity_columns_pass_through():
+    # With the narrative arm gone, every signal source selects from the
+    # canonical, so the LEFT JOIN can no longer actually produce NULLs. The
+    # join is kept defensively; this asserts the client still maps such a row
+    # cleanly if a future nonprofit_text-sourced signal reintroduces one.
     rows = [
         _row(
             "100000009",
@@ -280,8 +293,7 @@ def test_990ez_null_identity_columns_survive():
             city=None,
             state=None,
             latest_taxyear=None,
-            rank=3.2,
-            signal="narrative",
+            rank=1_000_000.0,
         )
     ]
     client, _ = _client([rows])
@@ -295,7 +307,7 @@ def test_990ez_null_identity_columns_survive():
             state=None,
             latest_taxyear=None,
             org_type="nonprofit",
-            rank=3.2,
-            signal="narrative",
+            rank=1_000_000.0,
+            signal="name",
         )
     ]

--- a/tests/test_client_identity_search.py
+++ b/tests/test_client_identity_search.py
@@ -157,7 +157,9 @@ def test_nonprofit_arm_emits_all_signal_ctes():
     assert "1500000.0::float8" in sql
     assert "1200000.0::float8" in sql
     assert "1000000.0::float8" in sql
-    assert "LEFT JOIN public.nonprofit_canonical" in sql
+    # Inner join — every signal source is nonprofit_canonical itself.
+    assert "JOIN public.nonprofit_canonical c USING (ein)" in sql
+    assert "LEFT JOIN" not in sql
     assert params["limit"] == 25
 
 
@@ -281,10 +283,9 @@ def test_limit_applied_after_merge():
 
 
 def test_null_identity_columns_pass_through():
-    # With the narrative arm gone, every signal source selects from the
-    # canonical, so the LEFT JOIN can no longer actually produce NULLs. The
-    # join is kept defensively; this asserts the client still maps such a row
-    # cleanly if a future nonprofit_text-sourced signal reintroduces one.
+    # The join is inner, but the canonical's own columns are nullable — real
+    # rows carry NULL name/city (e.g. ein 680475089). Those must survive as
+    # None rather than blowing up the dataclass construction.
     rows = [
         _row(
             "100000009",

--- a/tests/test_client_identity_search.py
+++ b/tests/test_client_identity_search.py
@@ -1,0 +1,301 @@
+"""
+Unit tests for ``GtDatamartClient.search_identity``.
+
+The identity-search SQL is Postgres-specific (ILIKE, websearch_to_tsquery,
+ARRAY_AGG, ::float8 casts), so these tests don't execute it — they assert
+the three things the client actually owns:
+
+1. input validation and signal normalization (EIN digits, URL → domain),
+2. SQL assembly (which CTEs are emitted for which signals, per arm),
+3. the cross-arm merge: ordering, limit slice, and hit construction.
+
+A fake session records every ``execute(sql, params)`` call and returns
+canned row batches, one batch per arm query, in execution order
+(nonprofit arm first, funder arm second).
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+
+from givingtuesday_datamart.client import GtDatamartClient, IdentityHit
+
+
+class _FakeResult:
+    def __init__(self, rows: list[dict]) -> None:
+        self._rows = rows
+
+    def mappings(self) -> "_FakeResult":
+        return self
+
+    def all(self) -> list[dict]:
+        return self._rows
+
+
+class _FakeSession:
+    """Records (sql, params) per execute; returns canned batches in order."""
+
+    def __init__(self, batches: list[list[dict]]) -> None:
+        self._batches = list(batches)
+        self.calls: list[tuple[str, dict]] = []
+
+    def execute(self, clause, params=None) -> _FakeResult:
+        self.calls.append((clause.text, params or {}))
+        return _FakeResult(self._batches.pop(0) if self._batches else [])
+
+    def close(self) -> None:
+        pass
+
+
+def _client(batches: list[list[dict]] | None = None) -> tuple[GtDatamartClient, _FakeSession]:
+    # sqlite:// never connects — the engine only exists so __init__ runs;
+    # the fake sessionmaker intercepts every query before any I/O.
+    client = GtDatamartClient(engine=create_engine("sqlite://"))
+    session = _FakeSession(batches or [])
+    client._sessionmaker = lambda: session
+    return client, session
+
+
+def _row(ein: str, **overrides) -> dict:
+    row = {
+        "ein": ein,
+        "name": f"Org {ein}",
+        "name_secondary": None,
+        "city": "Oakland",
+        "state": "CA",
+        "latest_taxyear": 2023,
+        "rank": 1_000_000.0,
+        "signal": "name",
+    }
+    row.update(overrides)
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_requires_at_least_one_signal():
+    client, _ = _client()
+    with pytest.raises(ValueError, match="at least one of name, url, or ein"):
+        client.search_identity()
+
+
+def test_blank_name_is_not_a_signal():
+    client, _ = _client()
+    with pytest.raises(ValueError, match="at least one of name, url, or ein"):
+        client.search_identity(name="   ")
+
+
+def test_rejects_malformed_ein():
+    client, _ = _client()
+    with pytest.raises(ValueError, match="9 digits"):
+        client.search_identity(ein="12-345")
+
+
+def test_rejects_non_domain_url():
+    client, _ = _client()
+    # Whitespace after stripping → not domain-shaped (frontend parity).
+    with pytest.raises(ValueError, match="searchable domain"):
+        client.search_identity(url="not a url")
+    # Shorter than 3 chars after normalization.
+    with pytest.raises(ValueError, match="searchable domain"):
+        client.search_identity(url="https://ab")
+
+
+def test_rejects_bad_org_type():
+    client, _ = _client()
+    with pytest.raises(ValueError, match="org_type"):
+        client.search_identity(name="x", org_type="foundation")
+
+
+# ---------------------------------------------------------------------------
+# Signal normalization → bound parameters
+# ---------------------------------------------------------------------------
+
+
+def test_ein_separators_stripped():
+    client, session = _client()
+    client.search_identity(ein="13-1234567")
+    assert len(session.calls) == 2  # both arms run on an EIN signal
+    for _, params in session.calls:
+        assert params["ein"] == "131234567"
+
+
+def test_url_normalized_to_domain_and_prefix():
+    client, session = _client()
+    client.search_identity(url="https://www.Example.org/about?utm=1")
+    (_, params), = session.calls
+    assert params["domain"] == "example.org"
+    assert params["domain_prefix"] == "example.org%"
+
+
+def test_name_binds_ilike_and_fts_params():
+    client, session = _client()
+    client.search_identity(name="Michael J Fox Foundation", org_type="nonprofit")
+    (_, params), = session.calls
+    assert params["like"] == "%Michael J Fox Foundation%"
+    assert params["raw_name"] == "Michael J Fox Foundation"
+
+
+# ---------------------------------------------------------------------------
+# SQL assembly per signal / arm
+# ---------------------------------------------------------------------------
+
+
+def test_nonprofit_arm_emits_all_signal_ctes():
+    client, session = _client()
+    client.search_identity(
+        name="fox", url="example.org", ein="131234567", org_type="nonprofit"
+    )
+    (sql, params), = session.calls
+    for cte in ("name_hits", "fts_hits", "ein_hits", "url_hits"):
+        assert cte in sql
+    # Tier constants ported from the frontend.
+    assert "2000000.0::float8" in sql
+    assert "1500000.0::float8" in sql
+    assert "1200000.0::float8" in sql
+    assert "1000000.0::float8" in sql
+    # websearch_to_tsquery + ts_rank_cd (not the plainto/ts_rank pair that
+    # search_nonprofits uses).
+    assert "websearch_to_tsquery('english'" in sql
+    assert "ts_rank_cd" in sql
+    # 990-EZ contract: narrative hits outside the canonical keep their row.
+    assert "LEFT JOIN public.nonprofit_canonical" in sql
+    assert params["limit"] == 25
+
+
+def test_unused_signals_are_not_emitted():
+    client, session = _client()
+    client.search_identity(name="fox", org_type="nonprofit")
+    (sql, _), = session.calls
+    assert "url_hits" not in sql
+    assert "ein_hits" not in sql
+    # The generated `domain` column may not exist on older canonical
+    # builds — it must never be referenced unless url was passed.
+    assert "domain" not in sql
+
+
+def test_include_narrative_false_drops_fts():
+    client, session = _client()
+    client.search_identity(name="fox", org_type="nonprofit", include_narrative=False)
+    (sql, _), = session.calls
+    assert "name_hits" in sql
+    assert "fts_hits" not in sql
+    assert "nonprofit_text" not in sql
+
+
+def test_funder_arm_is_name_and_ein_only():
+    client, session = _client()
+    client.search_identity(
+        name="fox", url="example.org", ein="131234567", org_type="funder"
+    )
+    (sql, _), = session.calls
+    assert "public.funder_canonical" in sql
+    assert "name_hits" in sql
+    assert "ein_hits" in sql
+    # No URL or narrative surface, and no DBA columns, on funders.
+    assert "url_hits" not in sql
+    assert "fts_hits" not in sql
+    assert "dba_1" not in sql
+
+
+def test_url_only_skips_funder_arm():
+    client, session = _client()
+    client.search_identity(url="example.org")  # org_type="all"
+    assert len(session.calls) == 1
+    assert "public.nonprofit_canonical" in session.calls[0][0]
+
+
+def test_url_only_funder_search_returns_empty_without_querying():
+    client, session = _client()
+    assert client.search_identity(url="example.org", org_type="funder") == []
+    assert session.calls == []
+
+
+def test_limit_none_omits_sql_limit():
+    client, session = _client()
+    client.search_identity(name="fox", org_type="nonprofit", limit=None)
+    (sql, params), = session.calls
+    assert "LIMIT" not in sql
+    assert "limit" not in params
+
+
+# ---------------------------------------------------------------------------
+# Cross-arm merge
+# ---------------------------------------------------------------------------
+
+
+def test_merge_orders_by_rank_then_taxyear_then_name_then_ein():
+    nonprofit_rows = [
+        _row("100000001", rank=1_000_000.0, latest_taxyear=2020, name="Alpha"),
+        _row("100000002", rank=12.5, latest_taxyear=2023, name="Narrative Hit", signal="narrative"),
+    ]
+    funder_rows = [
+        _row("200000001", rank=2_000_000.0, latest_taxyear=2019, name="EIN Winner", signal="ein"),
+        _row("200000002", rank=1_000_000.0, latest_taxyear=2020, name="Alpha"),
+    ]
+    client, _ = _client([nonprofit_rows, funder_rows])
+    hits = client.search_identity(name="x", ein="131234567")
+
+    assert [h.ein for h in hits] == [
+        "200000001",  # EIN tier beats everything despite oldest taxyear
+        "100000001",  # rank tie with 200000002, same year, same name → ein ASC
+        "200000002",
+        "100000002",  # raw FTS rank sorts below all fixed tiers
+    ]
+    assert [h.org_type for h in hits] == ["funder", "nonprofit", "funder", "nonprofit"]
+    assert hits[0].signal == "ein"
+    assert hits[3].signal == "narrative"
+
+
+def test_none_taxyear_sorts_last_within_tier():
+    rows = [
+        _row("100000001", latest_taxyear=None),
+        _row("100000002", latest_taxyear=2010),
+    ]
+    client, _ = _client([rows])
+    hits = client.search_identity(name="x", org_type="nonprofit")
+    assert [h.ein for h in hits] == ["100000002", "100000001"]
+
+
+def test_limit_applied_after_merge():
+    nonprofit_rows = [_row(f"10000000{i}", rank=1_000_000.0 + i) for i in range(3)]
+    funder_rows = [_row(f"20000000{i}", rank=2_000_000.0) for i in range(3)]
+    client, _ = _client([nonprofit_rows, funder_rows])
+    hits = client.search_identity(name="x", limit=4)
+    assert len(hits) == 4
+    # All three funder EIN-tier rows outrank every nonprofit name-tier row.
+    assert [h.org_type for h in hits] == ["funder", "funder", "funder", "nonprofit"]
+
+
+def test_990ez_null_identity_columns_survive():
+    rows = [
+        _row(
+            "100000009",
+            name=None,
+            name_secondary=None,
+            city=None,
+            state=None,
+            latest_taxyear=None,
+            rank=3.2,
+            signal="narrative",
+        )
+    ]
+    client, _ = _client([rows])
+    hits = client.search_identity(name="tutoring", org_type="nonprofit")
+    assert hits == [
+        IdentityHit(
+            ein="100000009",
+            name=None,
+            name_secondary=None,
+            city=None,
+            state=None,
+            latest_taxyear=None,
+            org_type="nonprofit",
+            rank=3.2,
+            signal="narrative",
+        )
+    ]


### PR DESCRIPTION
Adds identity resolution to `GtDatamartClient`, ported from the frontend's `searchOrgs` SQL (`frontend/src/lib/queries/search.ts`), in single-row and batched forms.

## Why

The VDL portfolio-comparison engagement needs to resolve nonprofits that arrive without an EIN (`vdl-project-template/docs/specs/phase1-intake-entity-resolution.md` §4.5). The frontend query already implements the ranked signal search the matcher needs and is proven in production, so the search design is inherited rather than invented. EIN-bearing rows keep using `get_nonprofits_by_ein`.

## What

```python
search_identity(name=None, url=None, ein=None, *, org_type="all", limit=25) -> list[IdentityHit]

search_identity_bulk(queries, *, org_type="all", include_url_prefix=False,
                     limit_per_query=25, chunk_size=500,
                     on_invalid="raise") -> dict[str, list[IdentityHit]]

iter_identity_universe(*, org_type="all", batch_size=10_000) -> Iterator[CanonicalIdentity]
```

Two arms — `nonprofit_canonical` (all signals) and `funder_canonical` (name + EIN only; funders have no website column). Ranking tiers are the frontend's, unchanged:

| Signal | Rank |
|---|---|
| EIN exact | 2,000,000 |
| URL exact-domain | 1,500,000 |
| URL prefix-domain | 1,200,000 |
| name/DBA ILIKE on `name` + `name_secondary` (+ `dba_1`/`dba_2`, nonprofit arm) | 1,000,000 |

`IdentityHit` carries `ein`, names, city/state, `latest_taxyear`, `org_type`, `rank`, and `signal` — the last computed in SQL via `ARRAY_AGG(signal ORDER BY rank DESC)`, so callers see *which* signal won the tier. Since every signal is now identity evidence, `signal` works directly as the §4.6 auto-accept gate: `ein` and `url_exact` are effectively exact matches, `name` is a substring hit that still needs a similarity check.

## The narrative-FTS tier is deliberately not ported

The frontend has a fifth tier — narrative FTS over `nonprofit_text` scored by `ts_rank_cd`. It's excluded here, and this is the one real divergence from "port the frontend SQL."

Identity resolution and topical search are different jobs. A match on 990 program narrative says an org *talks about* a subject, not that it *is* the org being sought. The ranking made that actively dangerous: narrative hits carry raw `ts_rank_cd` scores (~0–50) in a list whose other tiers are fixed at 1,000,000+, so whenever no real identity signal matched, a weak topical hit surfaced at rank 1 looking like an answer.

Measured on a real 121-row client portfolio:

- On the 26 rows with **no EIN** — the actual target case — narrative produced a candidate for 14 of them and was wrong essentially every time: "Freedom River Well Project" → CRAG LAW CENTER, "Women's Earth Alliance" → BLACK WOMEN FOR WELLNESS, "Santa Clara Clean Water Access Well" → TROUT UNLIMITED.
- On the 50 rows with a known EIN, it bought 4 points of top-1 recall (68% → 72%) while raising wrong-at-rank-1 from 4% to 6%. Name-only, it took wrong-at-#1 from 8% to **12%**.

Doubling the false-positive rate for 4 points of recall is a bad trade anywhere, and a worse one in entity resolution where a wrong match poisons every downstream stage. Removed rather than defaulted off, since an opt-in flag is a footgun for whoever flips it without reading the docstring. The capability isn't lost: `search_nonprofits` already does narrative FTS and returns those ranks unmixed with identity tiers.

Consequence: the `LEFT JOIN nonprofit_canonical` was there to carry 990-EZ filers reachable only through narrative. With that arm gone every signal selects from the arm's own canonical, so the join is collapsed to inner. This does **not** make identity columns non-nullable — the canonical's own `name`/`city`/`state` are nullable and real rows carry NULLs (e.g. EIN 680475089) — so `IdentityHit` keeps `str | None`.

## Bulk: N rows, not N round trips

At ~155ms round-trip, looping the single-row method costs 16 minutes for 1,000 rows and 81 for 5,000 — almost none of it real work (the EIN query executes in 2.4ms server-side). `search_identity_bulk` keys each input by the caller's own row id and collapses each signal into one query per arm per chunk. Measured on 300 real orgs:

| Lane | n | Batched | Serial | Speedup |
|---|---|---|---|---|
| EIN | 300 | 0.32s | ~70s | **218×** |
| URL exact | 245 | 0.33s | ~80s | **244×** |
| name | 25 | 13.8s | ~19s | 1.4× |

Results are returned for **every** input key (empty list included) so callers can zip back onto a dataframe without membership checks.

The name lane is the honest exception. `ILIKE '%x%'` is unindexable, so it's one sequential scan per name whether looped or batched — Postgres plans the batched form as a nested loop (confirmed via EXPLAIN), and batching only recovers the round trip. `iter_identity_universe` is the answer there: the whole canonical streams server-side in ~25s / ~57MB, after which name matching costs zero round trips and can use the blocking + Jaro-Winkler pattern already in `grant_matching.py`. Break-even is ~50 name-only rows.

Matching itself stays **out** of the client deliberately — it needs pandas and recordlinkage, and the client's base install is sqlalchemy + psycopg2 only so it can ship standalone.

## Other decisions worth review

- **Malformed input raises, it doesn't silently degrade.** An `ein` that doesn't strip to 9 digits or a `url` that doesn't normalize to a domain is a `ValueError`. The frontend degrades silently because it's a search box; for a matching pipeline, `"N/A"` quietly becoming a name-only search is a wrong-match risk. In bulk, validation runs over the whole batch *before* any query, so a bad row at input 4,000 costs no query time, and the error names every offending key. `on_invalid="skip"` drops just the bad signal for unwashed customer data.
- **URL prefix tier is opt-in in bulk** (`include_url_prefix=False`). `LIKE 'x%'` can't use the `domain` btree under this database's `en_US.UTF-8` collation, so it degrades to a scan per row — and prefix matching invites false positives on pipeline data, where URLs arrive normalized.
- **`limit_per_query` is pushed into SQL** as `ROW_NUMBER() OVER (PARTITION BY key)`, so one generic name like "foundation" can't drag back its entire match set, then re-applied after the cross-arm merge.

## Validation

Verified live against `gt_datamart` throughout; bulk output matches single-row output row-for-row across all four signals.

End-to-end on a real 121-row portfolio, searching by name/URL only against 50 rows with a Candid-sourced EIN as ground truth:

- **34/50 (68%) correct at rank 1**, wrong-at-#1 down to 2 (4%)
- **10 of the 50 EINs are absent from the datamart entirely** (neither canonical) — unreachable by any search. Against the 40 reachable rows, accuracy is **85%**
- Only 2 failures were genuine ranking errors ("NDN Collective" lost to "NDN ACTION NETWORK INC"), both the known ILIKE weakness: substring matching has no notion of similarity. A Jaro-Winkler tiebreak fixes them
- 27 of 38 correct answers came from `url_exact` — **getting websites onto portfolio rows is worth more than any matcher improvement**

## Two data findings for the pipeline

Both surfaced during validation and matter beyond this PR:

1. **27% of non-empty `domain` values in `nonprofit_canonical` are unusable** — 106,441 rows are literally `'n'` (the 990's "no website"), plus `'see schedule o'`, `'not applicable'`. Real URL-signal coverage is **61% of orgs, not the 85%** that `domain <> ''` implies. Not a correctness bug (those values are inert as match targets), but it caps what the URL tier can reach.
2. **Fiscal-sponsor EINs are not grantee EINs.** In the test portfolio, 45 of 121 rows carry the sponsor's EIN (41 of 42 exactly equal the `Fiscal Sponsor EIN` column), collapsing to just 34 distinct EINs — one sponsor covers 5 different grantees. Any pipeline treating an EIN column as grantee identity will silently merge distinct orgs and pool their grant amounts.

## Tests

**This repo had no Python tests**, so `tests/` is new scaffolding — flagging that as a repo-level decision, not just a file add. The SQL is Postgres-specific, so the 47 tests cover what the client owns — validation, parameter binding, conditional CTE assembly per arm, batching/chunking, the `on_invalid` contract, and the per-key merge/limit — against a fake session. SQL behavior was verified against the live database as above.

```bash
python -m pytest tests/ -q
```

## Known issue, not fixed here

The URL tier's `domain = :d OR domain LIKE :p` defeats the `ix_nonprofit_canonical_domain` index: `domain = :d` alone is a 0.037ms bitmap heap scan, but the `OR` makes it an 84ms full sequential scan. Splitting into two UNION-ed branches fixes the exact half; the prefix half needs a `text_pattern_ops` index to ever be fast. **This is existing production behavior in the frontend**, inherited by the port — worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
