### PR TITLE
basic_fields dedup Phase 2: _current relations + consumer cutover (closes #34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,10 +235,10 @@ Uses [`recordlinkage`](https://recordlinkage.readthedocs.io/) to compare
 private-grant recipient names + addresses against the filer universe
 (990 filers ∪ 990-PF filers ∪ the corrections registry —
 [`data/corrections/org_identities.csv`](data/corrections/org_identities.csv)).
-At the start of every run it reloads the corrections CSV, rebuilds the
-filing-version-deduped `_current` relations
-([`current_grants.py`](givingtuesday_datamart/current_grants.py), issue
-#33), and recreates the matching views — no separate step needed.
+At the start of every run it reloads the corrections CSV, rebuilds all
+four filing-version-deduped `_current` relations
+([`current_grants.py`](givingtuesday_datamart/current_grants.py), issues
+#33 and #34), and recreates the matching views — no separate step needed.
 
 Candidate-pair chunks are written to S3 keyed on the full input lineage:
 the source versions of `irs_990pf_grants` / `irs_990_basic_fields` /
@@ -292,7 +292,9 @@ python -m givingtuesday_datamart.sources refresh
 #    'success', row counts sane, warnings inspected.
 python -m givingtuesday_datamart.sources loaded
 
-# 4. Rebuild the canonical layer (reads staging only; ~10 min).
+# 4. Rebuild the canonical layer. Rebuilds basic_fields[_pf]_current
+#    first — the identity tables read those, and a staging refresh
+#    leaves them stale until something rebuilds them.
 python -m givingtuesday_datamart.sources build-canonical
 
 # 5. Corrections preflight (~10 min, any machine). Required after any

--- a/frontend/src/lib/db.ts
+++ b/frontend/src/lib/db.ts
@@ -49,6 +49,15 @@ interface BasicFieldsTable {
   suprreintoot: string | null;
 }
 
+// The *_current relations carry every staging column plus dedup provenance
+// (current_grants.py, issues #33/#34). Same shape, one row per
+// (filerein, taxyear) instead of one per filing version.
+interface BasicFieldsCurrentTable extends BasicFieldsTable {
+  n_filings_for_year: number;
+  // 'passthrough' | 'latest_filing' | 'duplicate_row'
+  dedup_rule: string;
+}
+
 interface UnionedGrantsTable {
   granter_ein: string;
   granter_name: string | null;
@@ -145,8 +154,13 @@ interface ScheduleOPartIIITable {
 }
 
 export interface Database {
-  'public.basic_fields': BasicFieldsTable;
-  'public.basic_fields_pf': BasicFieldsTable;
+  // Only the *_current relations are registered. Raw public.basic_fields /
+  // basic_fields_pf carry one row per filing version, so aggregating them
+  // double-counts amended filer-years (#34) — leaving them off the schema
+  // makes that a type error rather than a silent wrong number. Re-add them
+  // here if some future read genuinely needs per-version rows.
+  'public.basic_fields_current': BasicFieldsCurrentTable;
+  'public.basic_fields_pf_current': BasicFieldsCurrentTable;
   'public.unioned_grants': UnionedGrantsTable;
   'public.nonprofit_canonical': NonprofitCanonicalTable;
   'public.funder_canonical': FunderCanonicalTable;

--- a/frontend/src/lib/queries/orgs.ts
+++ b/frontend/src/lib/queries/orgs.ts
@@ -13,23 +13,31 @@ import type {
   RevenueDetail,
 } from '@/types/org';
 
-// basic_fields uses totrevcuryea; basic_fields_pf uses areterexpnss
+// Every read here goes to the *_current relations: raw staging carries one
+// row per filing version, so a filer who amended a return appears twice for
+// that tax year — SUMs double, and per-year tables show the year twice
+// (issue #34). current_grants.py owns the selection rule.
+type BasicFieldsSource =
+  | 'public.basic_fields_current'
+  | 'public.basic_fields_pf_current';
+
+const NONPROFIT_TABLE = 'public.basic_fields_current' as const;
+const FOUNDATION_TABLE = 'public.basic_fields_pf_current' as const;
+
+// 990 uses totrevcuryea; 990-PF uses areterexpnss
 const REVENUE_COL = {
-  'public.basic_fields': 'totrevcuryea',
-  'public.basic_fields_pf': 'areterexpnss',
+  [NONPROFIT_TABLE]: 'totrevcuryea',
+  [FOUNDATION_TABLE]: 'areterexpnss',
 } as const;
 
 // donoadvifund encoding in basic_fields: 'true'/'1' = Yes, 'false'/'0'/''/NULL = No.
 // Both encodings appear because the column's source CSV format shifts by tax year.
 const DAF_YES_SQL = sql<boolean>`donoadvifund IN ('1', 'true')`;
 
-async function fetchOrgFromTable(
-  table: 'public.basic_fields' | 'public.basic_fields_pf',
-  ein: string
-) {
+async function fetchOrgFromTable(table: BasicFieldsSource, ein: string) {
   const db = getDb();
   const revenueCol = REVENUE_COL[table];
-  const isNonprofit = table === 'public.basic_fields';
+  const isNonprofit = table === NONPROFIT_TABLE;
   const rows = await db
     .selectFrom(table)
     .select([
@@ -55,12 +63,13 @@ async function fetchOrgFromTable(
   return rows[0] ?? null;
 }
 
-// Per-year DAF flag for 990 filers. One row per (filerein, taxyear); when the
-// same year has multiple filings (amendments) we collapse with BOOL_OR.
+// Per-year DAF flag for 990 filers. _current is already one row per
+// (filerein, taxyear); the GROUP BY + BOOL_OR is retained as a cheap
+// belt-and-braces against a rebuild that ever regressed the grain.
 async function fetchDafByYear(ein: string): Promise<{ year: number; isDaf: boolean }[]> {
   const db = getDb();
   const rows = await db
-    .selectFrom('public.basic_fields')
+    .selectFrom(NONPROFIT_TABLE)
     .select([
       sql<number>`taxyear::int`.as('year'),
       sql<boolean>`BOOL_OR(${DAF_YES_SQL})`.as('is_daf'),
@@ -72,10 +81,7 @@ async function fetchDafByYear(ein: string): Promise<{ year: number; isDaf: boole
   return rows.map((r) => ({ year: r.year, isDaf: r.is_daf }));
 }
 
-async function fetchRevenueHistory(
-  table: 'public.basic_fields' | 'public.basic_fields_pf',
-  ein: string
-) {
+async function fetchRevenueHistory(table: BasicFieldsSource, ein: string) {
   const db = getDb();
   const revenueCol = REVENUE_COL[table];
   const rows = await db
@@ -101,11 +107,11 @@ function toInt(val: string | null | undefined): number | null {
 }
 
 async function fetchRevenueDetails(
-  table: 'public.basic_fields' | 'public.basic_fields_pf',
+  table: BasicFieldsSource,
   ein: string
 ): Promise<RevenueDetail[]> {
   const db = getDb();
-  const isNonprofit = table === 'public.basic_fields';
+  const isNonprofit = table === NONPROFIT_TABLE;
 
   if (isNonprofit) {
     const rows = await db
@@ -274,7 +280,7 @@ function buildSlot(desc: string | null, amount: string | null): ActivitySlot | n
 async function fetchFoundationActivities(ein: string): Promise<FoundationActivitiesYear[]> {
   const db = getDb();
   const rows = await db
-    .selectFrom('public.basic_fields_pf')
+    .selectFrom(FOUNDATION_TABLE)
     .select([
       sql<number>`taxyear::int`.as('year'),
       sql<string>`url::text`.as('url'),
@@ -355,8 +361,8 @@ async function getOrgProfileUncached(ein: string): Promise<OrgProfile | null> {
   const [npIdentity, pfIdentity, npAgg, pfAgg] = await Promise.all([
     fetchCanonicalIdentity('public.nonprofit_canonical', ein),
     fetchCanonicalIdentity('public.funder_canonical', ein),
-    fetchOrgFromTable('public.basic_fields', ein),
-    fetchOrgFromTable('public.basic_fields_pf', ein),
+    fetchOrgFromTable(NONPROFIT_TABLE, ein),
+    fetchOrgFromTable(FOUNDATION_TABLE, ein),
   ]);
 
   // 990 takes precedence when an EIN somehow appears in both surfaces.
@@ -365,7 +371,7 @@ async function getOrgProfileUncached(ein: string): Promise<OrgProfile | null> {
   if (!agg) return null;
   const identity = orgType === 'nonprofit' ? npIdentity : pfIdentity;
 
-  const table = orgType === 'nonprofit' ? 'public.basic_fields' : 'public.basic_fields_pf';
+  const table = orgType === 'nonprofit' ? NONPROFIT_TABLE : FOUNDATION_TABLE;
 
   const [revenueByYear, revenueDetails, missions, programs, scheduleO, foundationActivities, dafByYear] = await Promise.all([
     fetchRevenueHistory(table, ein),

--- a/frontend/src/lib/queries/search.ts
+++ b/frontend/src/lib/queries/search.ts
@@ -23,9 +23,9 @@ const SEARCH_CACHE_REVALIDATE_SECONDS = 600; // 10 minutes
 //     happens in JS, then the page slice is taken. Worst case data over the
 //     wire per request is 2 * (offset + limit) rows, not the entire match set.
 //   - firstYear comes from a per-page MIN(taxyear) lookup against
-//     public.basic_fields(_pf) on the filerein index (one query per arm,
-//     bounded by `limit` EINs). Real range like "2010–2023" instead of the
-//     canonical's latest year repeated.
+//     public.basic_fields(_pf)_current on the filerein index (one query per
+//     arm, bounded by `limit` EINs). Real range like "2010–2023" instead of
+//     the canonical's latest year repeated.
 
 type SearchHit = {
   ein: string;
@@ -142,7 +142,7 @@ async function searchNonprofits(
       -- Only materialized when dafOnly=true (gated by WHERE FALSE otherwise).
       -- donoadvifund encoding: '1'/'true'=Yes, '0'/'false'/empty/NULL=No.
       SELECT DISTINCT filerein::text AS ein
-      FROM public.basic_fields
+      FROM public.basic_fields_current
       WHERE ${dafOnly} AND donoadvifund IN ('1', 'true')
     )
     SELECT
@@ -247,7 +247,7 @@ async function searchFoundations(
 // EIN set (≤ page size). Returns a map ein → first_year; missing EINs (e.g.
 // canonical row exists but no basic_fields rows) just don't appear.
 async function fetchFirstYears(
-  table: 'public.basic_fields' | 'public.basic_fields_pf',
+  table: 'public.basic_fields_current' | 'public.basic_fields_pf_current',
   eins: string[],
 ): Promise<Map<string, number>> {
   if (eins.length === 0) return new Map();
@@ -324,8 +324,8 @@ async function runSearch(
   const npEins = paginated.filter((r) => r.org_type === 'nonprofit').map((r) => r.ein);
   const pfEins = paginated.filter((r) => r.org_type === 'foundation').map((r) => r.ein);
   const [npFirstYears, pfFirstYears] = await Promise.all([
-    fetchFirstYears('public.basic_fields', npEins),
-    fetchFirstYears('public.basic_fields_pf', pfEins),
+    fetchFirstYears('public.basic_fields_current', npEins),
+    fetchFirstYears('public.basic_fields_pf_current', pfEins),
   ]);
 
   return {

--- a/givingtuesday_datamart/canonical/build.py
+++ b/givingtuesday_datamart/canonical/build.py
@@ -9,6 +9,14 @@ tables, and we want query-time cost to be zero):
   ``DISTINCT ON (filerein)`` ordered by tax year desc, then tax-period-end
   desc, then ingested_at desc as a deterministic tiebreak.
 
+  Built from ``basic_fields_current``, not raw staging: the ordering above
+  cannot separate an original filing from its amendment (same taxyear, same
+  taxperend, and ``_ingested_at`` is constant within an ingest run), so on
+  staging the identity row for 5,315 EINs was an arbitrary pick between
+  versions — 619 of them disagreeing on name or address. Reading the deduped
+  relation makes that choice the same one every other consumer sees
+  (issue #34).
+
 * ``public.nonprofit_text`` — one row per EIN built from the **latest tax
   year only** across mission, programs activities 1/2/3, and Schedule O
   Part III narrative. Plain ``DISTINCT`` collapses byte-identical snippets
@@ -35,6 +43,7 @@ from sqlalchemy import text
 
 from givingtuesday_datamart._internal.db import get_session
 from givingtuesday_datamart._internal.logger import logger
+from givingtuesday_datamart.current_grants import build_basic_fields_current
 from givingtuesday_datamart.ingestion import (
     INGEST_RUNS_TABLE,
     META_SCHEMA,
@@ -256,7 +265,7 @@ def _build_nonprofit_canonical(session) -> int:
                 _ingest_run_id                          AS source_run_id,
                 _source_version                         AS source_version,
                 NOW() AT TIME ZONE 'UTC'                AS _built_at
-            FROM public.basic_fields
+            FROM public.basic_fields_current
             ORDER BY
                 filerein,
                 CAST(NULLIF(taxyear, '') AS INT) DESC NULLS LAST,
@@ -461,11 +470,12 @@ def _build_nonprofit_text(session) -> int:
 
 
 def _build_funder_canonical(session) -> int:
-    """DROP + CREATE + populate public.funder_canonical from basic_fields_pf.
+    """DROP + CREATE + populate public.funder_canonical from basic_fields_pf_current.
 
     Private-foundation identity table — mirrors ``nonprofit_canonical``'s
     selection logic (latest taxyear, then latest taxperend, then latest
-    ingested) but built against ``basic_fields_pf``. Funder classification
+    ingested), including its read of the deduped ``_current`` relation
+    rather than raw staging. Funder classification
     (DAF / community / corporate / family) is deliberately out of scope for
     v1 — it's a Phase 3 enrichment task that needs Candid data. v1 carries
     identity + address + contact only.
@@ -498,7 +508,7 @@ def _build_funder_canonical(session) -> int:
                 _ingest_run_id                          AS source_run_id,
                 _source_version                         AS source_version,
                 NOW() AT TIME ZONE 'UTC'                AS _built_at
-            FROM public.basic_fields_pf
+            FROM public.basic_fields_pf_current
             ORDER BY
                 filerein,
                 CAST(NULLIF(taxyear, '') AS INT) DESC NULLS LAST,
@@ -789,6 +799,12 @@ def build_canonical(*, include_people: bool = False) -> BuildResult:
     )
     try:
         with get_session(config=datamart_config()) as session:
+            # Refresh the filing-version-deduped inputs FIRST. Both identity
+            # builds read basic_fields[_pf]_current, and a staging refresh
+            # leaves those stale — the matching pipeline also rebuilds them,
+            # but it runs after this step in the routine-refresh runbook, so
+            # waiting for it would build canonical from the previous drop.
+            build_basic_fields_current(session.connection())
             # schedule_o_part_iii must land before nonprofit_text because the
             # text build reads from it. All builds share one transaction so
             # downstream consumers never see a half-built canonical layer.

--- a/givingtuesday_datamart/client/client.py
+++ b/givingtuesday_datamart/client/client.py
@@ -256,45 +256,20 @@ class GtDatamartClient:
         joins: list[str] = []
 
         if needs_basic:
-            # ``basic_fields`` carries one row per *filing version* — when a
-            # filer amends a return, the original and amended filings are
-            # both present for the same (filerein, taxyear). Keep only the
-            # latest version per year (amended preferred, MAX(url) tiebreak
-            # — the same rule current_grants.py applies on the grants side),
-            # then average across years; summing versions double-counts
-            # amended years (issue #34). The amend flag is NULL (not '') on
-            # non-amended filings — IS NOT DISTINCT FROM keeps the sort key
-            # boolean, where a plain = would put NULL first under DESC and
-            # prefer the original. filesha256 is a determinism tiebreak:
-            # some filer-years re-drop the same filing under one url.
-            #
-            # Contributions-present outranks the amend flag so a version
-            # that doesn't report the metric never wins: 247 filer-years
-            # (2018+) would otherwise read NULL and drop out of the AVG,
-            # from two mechanisms — 140 where the amended return keeps
-            # total revenue but omits the contributions breakdown, and 107
-            # where two accounting periods share one taxyear label and the
-            # newest url is a stub (revenue 0 or near-0). Selection stays
-            # row-level, so every value comes from one real filing rather
-            # than a per-column composite spanning two periods.
-            #
+            # ``basic_fields_current`` is already one row per (filerein,
+            # taxyear) — current_grants.py owns the filing-version
+            # selection rule (issue #34), so this is a plain average over
+            # years. Reading raw ``basic_fields`` here would sum original
+            # and amended filings together and inflate contributions.
             # The staging columns are all-TEXT; cast at query time.
             ctes.append(
                 """contrib_eligible AS (
                     SELECT filerein AS ein
-                    FROM (
-                        SELECT DISTINCT ON (filerein, taxyear)
-                               filerein, taxyear,
-                               NULLIF(totacashcont, '')::bigint AS yr_val
-                        FROM public.basic_fields
-                        WHERE NULLIF(taxyear, '')::int >= :min_taxyear
-                        ORDER BY filerein, taxyear,
-                                 (NULLIF(totacashcont, '') IS NOT NULL) DESC,
-                                 (amendereturn IS NOT DISTINCT FROM 'X') DESC,
-                                 url DESC, filesha256
-                    ) yearly
+                    FROM public.basic_fields_current
+                    WHERE NULLIF(taxyear, '')::int >= :min_taxyear
                     GROUP BY filerein
-                    HAVING AVG(yr_val) >= :min_avg_contributions
+                    HAVING AVG(NULLIF(totacashcont, '')::bigint)
+                           >= :min_avg_contributions
                 )"""
             )
             joins.append("JOIN contrib_eligible USING (ein)")
@@ -489,29 +464,23 @@ class GtDatamartClient:
         *,
         min_taxyear: int | None = None,
     ) -> list[BasicFieldsRow]:
-        """Multi-year staging reads from ``public.basic_fields``.
+        """Multi-year reads from ``public.basic_fields_current``.
 
-        Returns one row per (filerein, taxyear): ``basic_fields`` carries one
+        One row per (filerein, taxyear). Raw ``basic_fields`` carries one
         row per *filing version* (original + amended returns under the same
-        filer-year), and this method keeps only the latest version — amended
-        preferred, MAX(url) tiebreak, the same rule current_grants.py applies
-        on the grants side (issue #34). Consumers that sum or average across
-        the returned rows would otherwise double-count amended years.
+        filer-year); ``basic_fields_current`` applies the version-selection
+        rule once, in current_grants.py, so consumers can't accidentally
+        double-count amended years by summing or averaging these rows
+        (issue #34).
 
-        Version selection prefers a filing that actually reports
-        ``totacashcont``: an amended return sometimes carries total revenue
-        without re-stating the contributions breakdown, and where two
-        accounting periods share one taxyear label the newest url can be a
-        near-empty stub. Both would otherwise blank out contributions the
-        filer did report. The whole row comes from the selected filing —
-        values are never COALESCEd across versions, which in the
-        split-period case would blend two different accounting periods into
-        a row matching no real filing. Consequence worth knowing: when the
-        amendment omits contributions, ``total_revenue_current_year`` comes
-        from the earlier version too, so it can trail an amended revenue
-        figure by a small amount.
+        Worth knowing about that rule, since it shows up here: selection is
+        row-level, so every column comes from one real filing rather than a
+        composite. When an amendment omits the contributions breakdown, the
+        earlier version wins the row and ``total_revenue_current_year``
+        comes from it too — so it can trail an amended revenue figure by a
+        small amount.
 
-        Staging is all-TEXT, so every numeric column is cast at query time
+        Columns are all-TEXT, so every numeric one is cast at query time
         via ``NULLIF(col, '')::bigint``. ``governgrants`` is COALESCEd to 0
         when computing ``total_cash_contributions_no_gov`` because empty
         string is much more common than NULL in the staging data, and we
@@ -523,7 +492,7 @@ class GtDatamartClient:
 
         params: dict[str, object] = {"eins": list(eins)}
         sql = """
-            SELECT DISTINCT ON (filerein, taxyear)
+            SELECT
                 filerein                                AS ein,
                 filername1                              AS name,
                 filername2                              AS name_secondary,
@@ -539,18 +508,13 @@ class GtDatamartClient:
                 (NULLIF(totacashcont, '')::bigint
                     - COALESCE(NULLIF(governgrants, '')::bigint, 0))
                                                         AS total_cash_contributions_no_gov
-            FROM public.basic_fields
+            FROM public.basic_fields_current
             WHERE filerein = ANY(:eins)
         """
         if min_taxyear is not None:
             sql += " AND NULLIF(taxyear, '')::int >= :min_taxyear"
             params["min_taxyear"] = min_taxyear
-        sql += """
-            ORDER BY filerein, taxyear,
-                     (NULLIF(totacashcont, '') IS NOT NULL) DESC,
-                     (amendereturn IS NOT DISTINCT FROM 'X') DESC,
-                     url DESC, filesha256
-        """
+        sql += " ORDER BY filerein, taxyear"
 
         with self._session() as session:
             rows = session.execute(text(sql), params).mappings().all()
@@ -750,11 +714,21 @@ class GtDatamartClient:
         """Return EINs whose avg yearly value of ``column`` is ``>= min_avg``.
 
         Pushes the avg-contributions filter into Postgres so the caller
-        doesn't pull all per-year staging rows just to compute a Python
+        doesn't pull all per-year rows just to compute a Python
         groupby/mean. Mirrors the all-TEXT casting used by ``get_basic_fields``.
 
         Restricted to the two cash-flow columns the existing pipeline filters
         on; whitelisted (not interpolated user input) so it's safe to embed.
+
+        Both columns read ``basic_fields_current``, whose version selection
+        is keyed on ``totacashcont``. For ``column='totrevcuryea'`` that
+        means the row wasn't chosen on the metric being averaged — measured
+        cost: it differs from a revenue-keyed pick on 270 of 3.8M
+        filer-years, and in **0** cases does the selected row blank a
+        revenue an earlier version reported, so no year silently drops out
+        of the AVG. Worth the consistency: every metric for a filer-year now
+        comes from the same filing, where per-column keying could hand
+        ``get_basic_fields`` and this method different rows for one year.
         """
         if not eins:
             return []
@@ -768,30 +742,16 @@ class GtDatamartClient:
             "min_taxyear": min_taxyear,
             "min_avg": min_avg,
         }
-        # ``basic_fields`` carries one row per *filing version* for the same
-        # (filerein, taxyear) — original + amended returns. Keep only the
-        # latest version per year (amended preferred, MAX(url) tiebreak,
-        # filesha256 for determinism — the current_grants.py rule), then
-        # average across years; summing versions double-counts amended years
-        # (issue #34). Presence of the thresholded column outranks the amend
-        # flag so a version that doesn't report it never wins and silently
-        # drops the year from the AVG — see the note in search_nonprofits.
+        # ``basic_fields_current`` is one row per (filerein, taxyear), so
+        # this is a plain average over years — reading raw ``basic_fields``
+        # would sum original and amended filings together (issue #34).
         sql = f"""
             SELECT filerein AS ein
-            FROM (
-                SELECT DISTINCT ON (filerein, taxyear)
-                       filerein, taxyear,
-                       NULLIF({column}, '')::bigint AS yr_val
-                FROM public.basic_fields
-                WHERE filerein = ANY(:eins)
-                  AND NULLIF(taxyear, '')::int >= :min_taxyear
-                ORDER BY filerein, taxyear,
-                         (NULLIF({column}, '') IS NOT NULL) DESC,
-                         (amendereturn IS NOT DISTINCT FROM 'X') DESC,
-                         url DESC, filesha256
-            ) yearly
+            FROM public.basic_fields_current
+            WHERE filerein = ANY(:eins)
+              AND NULLIF(taxyear, '')::int >= :min_taxyear
             GROUP BY filerein
-            HAVING AVG(yr_val) >= :min_avg
+            HAVING AVG(NULLIF({column}, '')::bigint) >= :min_avg
         """
         logger.info(
             "find_eins_with_min_avg_contributions: %d EIN(s), column=%s, min_taxyear=%s, min_avg=%s",

--- a/givingtuesday_datamart/current_grants.py
+++ b/givingtuesday_datamart/current_grants.py
@@ -1,11 +1,12 @@
-"""Filing-version dedup: canonical `_current` relations over grants staging.
+"""Filing-version dedup: canonical `_current` relations over GT staging.
 
-GT's grants extracts emit line items for every filing version of a
-filer-year (original + amended returns), and recent PF batches double
-whole blocks outright — see GitHub issue #33 for the full evidence. The
-staging tables stay byte-faithful to the source (that invariant is what
-proved the bug was upstream); correction happens here, in two
-materialized relations consumers read instead of raw staging:
+GT's extracts emit a row for every filing version of a filer-year
+(original + amended returns), and recent PF batches double whole grant
+blocks outright — see GitHub issues #33 (grants) and #34 (basic fields)
+for the full evidence. The staging tables stay byte-faithful to the
+source (that invariant is what proved the bug was upstream); correction
+happens here, in four materialized relations consumers read instead of
+raw staging:
 
 * ``public.grants_to_domestic_organizations_current`` (990 Schedule I)
     1. latest_url — where a filer-year has multiple ``url``s (original +
@@ -45,11 +46,45 @@ materialized relations consumers read instead of raw staging:
        legitimate filer can't be halved unless it itemizes ~2x its own
        declared total).
 
-Every surviving row carries provenance: ``n_urls_for_year``,
+* ``public.basic_fields_current`` (990 filer financials, issue #34)
+* ``public.basic_fields_pf_current`` (990-PF filer financials)
+    One row per ``(filerein, taxyear)``, chosen by ``DISTINCT ON``. These
+    are whole-return versions rather than line items, so there is nothing
+    to collapse — the rule is purely "which version wins":
+      1. a version that actually REPORTS the metric beats one that leaves
+         it blank (990 only, keyed on ``totacashcont``). Measured on the
+         2026_06 drops: 247 filer-years (2018+) would otherwise read NULL
+         where an earlier version carried a number — 140 amended returns
+         that restate total revenue but omit the contributions breakdown,
+         107 where two accounting periods share one taxyear label and the
+         newest url is a near-empty stub (that grain problem is issue #37,
+         which version selection cannot fix). The PF side needs no such
+         key: 0 of 26,047 multi-version PF filer-years blank either
+         ``areterexpnss`` or ``arecgpdcprps``. Add one there only if a
+         future drop changes that.
+      2. prefer ``amendereturn = 'X'`` (990 only — ``basic_fields_pf``
+         carries no amend flag).
+      3. tiebreak ``MAX(url)``, then ``filesha256`` for determinism:
+         23,365 filer-years carry multiple shas under a single url.
+    Selection is row-level, never a per-column COALESCE across versions —
+    in the split-period cases a composite would pair one period's revenue
+    with another period's contributions, producing a row that matches no
+    real filing.
+
+    NOTE: the Schedule I and PF grant rules above deliberately keep
+    reading RAW ``basic_fields``/``basic_fields_pf`` for their amendment
+    evidence and declared-total lookups. Repointing them at these
+    relations would change which version supplies ``arecgpdcprps``, hence
+    which filer-years pair_collapse fires on, hence matching inputs — a
+    gate-moving change that does not belong in a consumer-side fix.
+
+Every surviving row carries provenance: ``n_urls_for_year`` (grants),
 ``n_filings_for_year`` (distinct shas in basic_fields[_pf]), and
-``dedup_rule`` (``passthrough`` | ``latest_url`` | ``amend_distinct`` |
-``pair_collapse``, ``+``-joined when both applied) — so every kept or
-dropped row is explainable from the relation alone.
+``dedup_rule`` — ``passthrough`` | ``latest_url`` | ``amend_distinct`` |
+``pair_collapse`` (``+``-joined when both applied) on the grants side,
+``passthrough`` | ``latest_filing`` | ``duplicate_row`` on the basic
+fields side — so every kept or dropped row is explainable from the
+relation alone.
 
 Builds are DROP + CREATE TABLE AS (idempotent) with (filerein) and
 (filerein, taxyear) indexes + ANALYZE. The DROP cascades to the matching
@@ -69,6 +104,56 @@ from givingtuesday_datamart._internal.logger import logger
 from givingtuesday_datamart.ingestion import datamart_config
 
 _NUMERIC_RE = r"'^-?[0-9]+(\.[0-9]+)?$'"
+
+# Filer-financial relations: whole-return version selection, no line-item
+# collapsing. `b.*` rather than an explicit column list — basic_fields
+# carries 168 columns and basic_fields_pf 141, the order is whatever
+# staging has, and a hardcoded list would silently drop columns the next
+# GT drop adds. (The grants DDL below can't do this: its content-hash
+# needs every column named.)
+_BASIC_FIELDS_SELECT = """
+DROP TABLE IF EXISTS public.{table}_current CASCADE;
+CREATE TABLE public.{table}_current AS
+WITH filings AS (
+    SELECT filerein, taxyear,
+           COUNT(*)                   AS n_rows_for_year,
+           COUNT(DISTINCT filesha256) AS n_filings_for_year
+    FROM public.{table}
+    GROUP BY 1, 2
+)
+SELECT DISTINCT ON (b.filerein, b.taxyear)
+       b.*,
+       f.n_filings_for_year,
+       CASE
+           WHEN f.n_filings_for_year >= 2 THEN 'latest_filing'
+           WHEN f.n_rows_for_year > 1     THEN 'duplicate_row'
+           ELSE 'passthrough'
+       END AS dedup_rule
+FROM public.{table} b
+JOIN filings f
+  ON f.filerein = b.filerein
+ AND f.taxyear IS NOT DISTINCT FROM b.taxyear
+ORDER BY b.filerein, b.taxyear,
+{order_keys}         b.url DESC, b.filesha256;
+"""
+
+# 990: value-present outranks the amend flag, so an amended return that
+# omits the contributions breakdown can't blank a figure the filer did
+# report (issue #34).
+_BASIC_FIELDS_CURRENT_DDL = _BASIC_FIELDS_SELECT.format(
+    table="basic_fields",
+    order_keys=(
+        "         (NULLIF(b.totacashcont, '') IS NOT NULL) DESC,\n"
+        "         (b.amendereturn IS NOT DISTINCT FROM 'X') DESC,\n"
+    ),
+)
+
+# 990-PF: no amend flag exists, and no measured blank-latest cases
+# (0/26,047 multi-version filer-years), so url order alone decides.
+_BASIC_FIELDS_PF_CURRENT_DDL = _BASIC_FIELDS_SELECT.format(
+    table="basic_fields_pf",
+    order_keys="",
+)
 
 # Line-item content columns — everything except provenance (url,
 # filesha256) and ingestion metadata. Two rows are "the same line item"
@@ -280,6 +365,16 @@ SET dedup_rule = 'passthrough' WHERE dedup_rule = '';
 """
 
 _INDEX_DDL = {
+    "basic_fields_current": [
+        "CREATE INDEX ix_bf_current_filerein ON public.basic_fields_current (filerein)",
+        "CREATE UNIQUE INDEX ix_bf_current_filerein_taxyear ON public.basic_fields_current (filerein, taxyear)",
+        "ANALYZE public.basic_fields_current",
+    ],
+    "basic_fields_pf_current": [
+        "CREATE INDEX ix_bfpf_current_filerein ON public.basic_fields_pf_current (filerein)",
+        "CREATE UNIQUE INDEX ix_bfpf_current_filerein_taxyear ON public.basic_fields_pf_current (filerein, taxyear)",
+        "ANALYZE public.basic_fields_pf_current",
+    ],
     "grants_to_domestic_organizations_current": [
         "CREATE INDEX ix_gtdo_current_filerein ON public.grants_to_domestic_organizations_current (filerein)",
         "CREATE INDEX ix_gtdo_current_filerein_taxyear ON public.grants_to_domestic_organizations_current (filerein, taxyear)",
@@ -293,14 +388,21 @@ _INDEX_DDL = {
 }
 
 
-_TABLES = (
+_BASIC_FIELDS_TABLES = (
+    ("basic_fields_current", _BASIC_FIELDS_CURRENT_DDL),
+    ("basic_fields_pf_current", _BASIC_FIELDS_PF_CURRENT_DDL),
+)
+_GRANTS_TABLES = (
     ("grants_to_domestic_organizations_current", _SCHED_I_CURRENT_DDL),
     ("privategrants_current", _PF_CURRENT_DDL),
 )
+_TABLES = _BASIC_FIELDS_TABLES + _GRANTS_TABLES
 
 
 def _build_one(connection, table: str, ddl: str) -> int:
-    logger.info("Building public.%s (issue #33 filing-version dedup)", table)
+    logger.info(
+        "Building public.%s (filing-version dedup, issues #33/#34)", table
+    )
     # RDS-default work_mem (4MB) makes the 9-17M-row hash/window passes
     # spill to thousands of temp-file batches (observed as sustained
     # IO:BufFileRead waits on the db.t4g.medium). One build runs at a
@@ -320,8 +422,23 @@ def _build_one(connection, table: str, ddl: str) -> int:
     return count
 
 
-def build_current_grants(connection) -> dict[str, int]:
-    """(Re)build both `_current` relations. Returns row counts.
+def build_basic_fields_current(connection) -> dict[str, int]:
+    """(Re)build just the two filer-financial relations. Returns row counts.
+
+    Split out from the full rebuild for the canonical layer, which reads
+    ``basic_fields_current`` / ``basic_fields_pf_current`` but has no
+    interest in the grants relations — those are the expensive ones
+    (10-30 min each against 11-20 GB) and rebuilding them would triple
+    the canonical build for nothing.
+    """
+    return {
+        table: _build_one(connection, table, ddl)
+        for table, ddl in _BASIC_FIELDS_TABLES
+    }
+
+
+def build_current_relations(connection) -> dict[str, int]:
+    """(Re)build all four `_current` relations. Returns row counts.
 
     NOTE: the DROP ... CASCADE removes any views defined over
     ``privategrants_current`` (the matching keys/unique views). Callers
@@ -351,6 +468,12 @@ if __name__ == "__main__":
             UNION ALL
             SELECT 'pf', dedup_rule, COUNT(*)
             FROM public.privategrants_current GROUP BY 1, 2
+            UNION ALL
+            SELECT 'basic_fields', dedup_rule, COUNT(*)
+            FROM public.basic_fields_current GROUP BY 1, 2
+            UNION ALL
+            SELECT 'basic_fields_pf', dedup_rule, COUNT(*)
+            FROM public.basic_fields_pf_current GROUP BY 1, 2
             ORDER BY 1, 3 DESC
         """)).fetchall()
     for side, rule, n in rules:

--- a/givingtuesday_datamart/grant_matching.py
+++ b/givingtuesday_datamart/grant_matching.py
@@ -20,7 +20,7 @@ from givingtuesday_datamart._internal.address_cleaning import create_clean_addre
 from givingtuesday_datamart._internal.db import get_session
 from givingtuesday_datamart._internal.logger import logger
 from givingtuesday_datamart._internal.parquet_cache import _decode_json as _pqc_decode_json
-from givingtuesday_datamart.current_grants import build_current_grants
+from givingtuesday_datamart.current_grants import build_current_relations
 from givingtuesday_datamart.ingestion import datamart_config
 from givingtuesday_datamart.canonical.build import (
     CANONICAL_BUILDS_TABLE,
@@ -963,10 +963,11 @@ def _do_match_records(
     with get_session(config=datamart_config()) as session:
         connection = session.connection()
         _load_corrections(connection)
-        # Rebuild the filing-version-deduped inputs (issue #33) BEFORE the
-        # views: the DROP ... CASCADE inside takes the dependent matching
-        # views with it, and create_or_replace_views restores them.
-        build_current_grants(connection)
+        # Rebuild the filing-version-deduped inputs (issues #33/#34)
+        # BEFORE the views: the DROP ... CASCADE inside takes the
+        # dependent matching views with it, and create_or_replace_views
+        # restores them.
+        build_current_relations(connection)
         create_or_replace_views(connection)
         if s3_prefix is None:
             s3_prefix = _resolve_checkpoint_prefix(connection)


### PR DESCRIPTION
Phase 2 of #34. Phase 1 ([#35](https://github.com/vibrant-data-labs/givingtuesday-datamart/pull/35)) fixed the filing-version double-count inside three client queries; this moves the rule into the data layer so there is exactly one implementation, and repoints every consumer at it.

**The tables are already built on the datamart** — this PR is code + a rule that has been validated against them.

## The relations

| relation | rows | staging | versions dropped | build |
|---|---|---|---|---|
| `basic_fields_current` | 3,813,736 | 3,939,773 | 126,037 | 4.9 min |
| `basic_fields_pf_current` | 1,158,259 | 1,187,168 | 28,909 | 6.7 min |

```
basic_fields_current          basic_fields_pf_current
  passthrough    3,691,291      passthrough    1,129,836
  latest_filing     80,966      duplicate_row     15,617
  duplicate_row     41,479      latest_filing     12,806
```

`DISTINCT ON (filerein, taxyear)` ordered value-present → amend flag → url → filesha256. Three deliberate choices:

- **`b.*` instead of a column list.** `basic_fields` has 168 columns and `basic_fields_pf` 141; a hardcoded list would silently drop whatever the next GT drop adds. The grants DDL can't do this because its content-hash needs every column named — these relations have no line items to hash.
- **The `(filerein, taxyear)` index is UNIQUE.** The grain is a build-time assertion: a rule that ever stopped producing one row per filer-year fails the build instead of quietly shipping duplicates.
- **No value-present key on the PF side.** Measured: 0 of 26,047 multi-version PF filer-years blank either `areterexpnss` or `arecgpdcprps`, so adding one would be untested machinery. Documented in the module docstring with the number, and where to add it if a future drop changes that.

## Consumers repointed

Three client queries, five frontend call sites, both canonical identity builds. The fifth frontend site — `fetchFoundationActivities` — wasn't in the issue's audit table; it reads `basic_fields_pf` and emitted one row per filing version.

## Two things the plan didn't anticipate

**`build-canonical` runs before matching in the routine-refresh runbook.** Pointing the identity builds at `_current` would therefore have built them from the *previous* drop's data after every refresh — matching rebuilds `_current`, but it runs later. `build_canonical` now refreshes the two basic-fields relations first, via a new `build_basic_fields_current()` that skips the 10–30 min grants builds. README step 4 no longer claims canonical "reads staging only".

**Raw `basic_fields`/`basic_fields_pf` are off the frontend's Kysely schema entirely.** Reading per-version staging from the frontend is now a type error rather than a silent wrong number. Re-add them if some future read genuinely needs per-version rows.

## Matching: deliberately untouched

The universe views (`basic_fields_*_unique_names_view`) still read raw staging, and matching never reads canonical — verified by grep, both in the PR. So **no `MATCHING_INPUT_SHAPE_VERSION` bump, no corrections preflight, no gate rerun**, and gate numbers cannot move. This is the decision #34 asked to be made explicitly either way. The one cost: matching runs pick up ~11.5 min of extra rebuild time, since `_TABLES` now has four entries.

The grants DDL also keeps reading raw staging for its amendment evidence and declared-total lookups. Repointing those would change which version supplies `arecgpdcprps`, hence which filer-years `pair_collapse` fires on, hence matching inputs — a gate-moving change that doesn't belong in a consumer-side fix.

## Validation

**Grain** — 0 duplicate filer-years in either relation; row counts equal staging's distinct `(filerein, taxyear)` exactly.

**Parity with the Phase 1 rule** (same rule implemented twice, so they must agree):

```
set parity, eligibility thresholds:
  min_avg=    100,000: inline=256,216 current=256,216 symmetric_diff=0
  min_avg=  1,000,000: inline= 71,162 current= 71,162 symmetric_diff=0
  min_avg= 10,000,000: inline= 10,437 current= 10,437 symmetric_diff=0

per-year values, 300 messiest EINs: 3,587 filer-years, 0 mismatched
find_eins_with_min_avg_contributions, 500 EINs:
  totacashcont   inline=429 current=429 symmetric_diff=0
  totrevcuryea   inline=490 current=490 symmetric_diff=0
```

**Dollar parity 2018+**: `$4,836.5B`, matching the inline rule to the dollar. That's **$1.49B above the figure in #34** — not a discrepancy but the issue's own repro query being wrong in two ways Phase 1 fixed: `(amendereturn = 'X') DESC` puts NULL first and so preferred the *original*, and it had no value-present key.

**The `totrevcuryea` question.** `find_eins_with_min_avg_contributions` accepts `column='totrevcuryea'`, but `_current`'s row is selected on `totacashcont` presence, so I measured before converting it: differs from a revenue-keyed pick on **270 of 3.8M** filer-years (0.007%), and in **0** cases does the selected row blank a revenue an earlier version reported — so no year can silently drop out of the average. Converting is also a small correctness gain: every metric for a filer-year now comes from the same filing, where per-column keying could hand `get_basic_fields` and this method different rows for one year.

**Frontend**, verified against the running dev server:

| org | before | after |
|---|---|---|
| JAR OF HOPE (46-4134019) | $12,301,257 over 19 filing rows | **$4,976,718** over 9 years |
| BELLE PLAINE FRIENDS OF THE LIBRARY (36-3474532) | $25,797,280 over 14 rows | **$7,033,413** over 7 years |

Both profile types, search, and the DAF filter render with no console or server errors. Note the DAF filter now returns 6,048 eligible EINs rather than 6,061 — 13 orgs whose DAF flag lives only on a superseded filing version. That's the intended semantic change flagged in the plan (latest filing's flag, not any-version-true).

## Related

- Closes #34.
- #37 — filed from the Phase 1 investigation: two accounting periods sharing one `taxyear` label. Version selection can't fix it and this PR doesn't try; the relations inherit the limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
