### PR TITLE
Rebuild basic-fields _current in refresh, not build-canonical (follow-up to #38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,15 +286,21 @@ python -m givingtuesday_datamart.sources loaded
 
 # 2. Refresh staging. Validation (hard-fail + soft-warn) runs per
 #    source automatically; already-loaded (source, version) pairs skip.
+#    Reloading basic_fields / basic_fields_pf also rebuilds their
+#    _current relations (~11.5 min) — the client, the frontend and the
+#    canonical identity builds read those, so a reload that left them
+#    behind would serve the previous drop. The grants _current relations
+#    are NOT rebuilt here; matching owns those.
 python -m givingtuesday_datamart.sources refresh
 
 # 3. Verify the refresh before building anything on top: every source
 #    'success', row counts sane, warnings inspected.
 python -m givingtuesday_datamart.sources loaded
 
-# 4. Rebuild the canonical layer. Rebuilds basic_fields[_pf]_current
-#    first — the identity tables read those, and a staging refresh
-#    leaves them stale until something rebuilds them.
+# 4. Rebuild the canonical layer (~10 min). Checks that
+#    basic_fields[_pf]_current match staging before building identity
+#    from them, and rebuilds only if they don't — normally a no-op,
+#    since step 2 already did it.
 python -m givingtuesday_datamart.sources build-canonical
 
 # 5. Corrections preflight (~10 min, any machine). Required after any

--- a/givingtuesday_datamart/canonical/build.py
+++ b/givingtuesday_datamart/canonical/build.py
@@ -43,7 +43,10 @@ from sqlalchemy import text
 
 from givingtuesday_datamart._internal.db import get_session
 from givingtuesday_datamart._internal.logger import logger
-from givingtuesday_datamart.current_grants import build_basic_fields_current
+from givingtuesday_datamart.current_grants import (
+    build_basic_fields_current,
+    stale_basic_fields_current,
+)
 from givingtuesday_datamart.ingestion import (
     INGEST_RUNS_TABLE,
     META_SCHEMA,
@@ -799,12 +802,21 @@ def build_canonical(*, include_people: bool = False) -> BuildResult:
     )
     try:
         with get_session(config=datamart_config()) as session:
-            # Refresh the filing-version-deduped inputs FIRST. Both identity
-            # builds read basic_fields[_pf]_current, and a staging refresh
-            # leaves those stale — the matching pipeline also rebuilds them,
-            # but it runs after this step in the routine-refresh runbook, so
-            # waiting for it would build canonical from the previous drop.
-            build_basic_fields_current(session.connection())
+            # Both identity builds read basic_fields[_pf]_current. The
+            # ingestion path rebuilds those as part of any refresh that
+            # reloads their source, so this is normally a no-op — but it
+            # is checked rather than assumed, because building identity
+            # from the previous drop is silent and would persist until
+            # someone noticed a stale name or a missing EIN. The guard is
+            # two scalar reads per relation.
+            stale = stale_basic_fields_current(session.connection())
+            if stale:
+                logger.warning(
+                    "%s stale or missing — rebuilding before identity builds. "
+                    "Expected only if staging was loaded outside `sources refresh`.",
+                    ", ".join(stale),
+                )
+                build_basic_fields_current(session.connection(), only=stale)
             # schedule_o_part_iii must land before nonprofit_text because the
             # text build reads from it. All builds share one transaction so
             # downstream consumers never see a half-built canonical layer.

--- a/givingtuesday_datamart/current_grants.py
+++ b/givingtuesday_datamart/current_grants.py
@@ -97,6 +97,8 @@ these tables and then recreates its views at the start of every run
 
 from __future__ import annotations
 
+from typing import Iterable
+
 from sqlalchemy import text
 
 from givingtuesday_datamart._internal.db import get_session
@@ -422,19 +424,61 @@ def _build_one(connection, table: str, ddl: str) -> int:
     return count
 
 
-def build_basic_fields_current(connection) -> dict[str, int]:
-    """(Re)build just the two filer-financial relations. Returns row counts.
+def build_basic_fields_current(
+    connection, *, only: Iterable[str] | None = None
+) -> dict[str, int]:
+    """(Re)build the two filer-financial relations. Returns row counts.
 
-    Split out from the full rebuild for the canonical layer, which reads
-    ``basic_fields_current`` / ``basic_fields_pf_current`` but has no
-    interest in the grants relations — those are the expensive ones
-    (10-30 min each against 11-20 GB) and rebuilding them would triple
-    the canonical build for nothing.
+    Split out from the full rebuild because these are what the ingestion
+    path and the canonical layer care about: the grants relations are the
+    expensive ones (10-30 min each against 11-20 GB) and are read only by
+    the matching pipeline, which rebuilds them itself at the start of
+    every run.
+
+    ``only`` restricts the rebuild to the named ``_current`` relations —
+    a refresh of just ``irs_990pf_basic_fields`` has no reason to rebuild
+    the 990 side.
     """
-    return {
-        table: _build_one(connection, table, ddl)
-        for table, ddl in _BASIC_FIELDS_TABLES
-    }
+    wanted = _BASIC_FIELDS_TABLES
+    if only is not None:
+        keep = set(only)
+        wanted = tuple((t, d) for t, d in _BASIC_FIELDS_TABLES if t in keep)
+    return {table: _build_one(connection, table, ddl) for table, ddl in wanted}
+
+
+def stale_basic_fields_current(connection) -> list[str]:
+    """Which filer-financial ``_current`` relations no longer match staging.
+
+    A refresh replaces its whole staging table in a single ingest run, so
+    every staging row carries that run's ``_ingest_run_id``. A ``_current``
+    relation whose id differs was built from an older drop; one that
+    doesn't exist yet counts as stale too.
+
+    Lets consumers guard cheaply (two scalar reads per relation) instead
+    of rebuilding unconditionally — the ingestion path already rebuilds
+    these, so the usual answer is "nothing to do".
+    """
+    stale: list[str] = []
+    for table, _ddl in _BASIC_FIELDS_TABLES:
+        source = table[: -len("_current")]
+        exists = connection.execute(
+            text(f"SELECT to_regclass('public.{table}') IS NOT NULL")
+        ).scalar_one()
+        if not exists:
+            stale.append(table)
+            continue
+        mismatch = connection.execute(
+            text(
+                f"""
+                SELECT (SELECT MAX(_ingest_run_id::text) FROM public.{source})
+                       IS DISTINCT FROM
+                       (SELECT MAX(_ingest_run_id::text) FROM public.{table})
+                """
+            )
+        ).scalar_one()
+        if mismatch:
+            stale.append(table)
+    return stale
 
 
 def build_current_relations(connection) -> dict[str, int]:

--- a/givingtuesday_datamart/sources/__main__.py
+++ b/givingtuesday_datamart/sources/__main__.py
@@ -294,6 +294,64 @@ def cmd_build_canonical(*, include_people: bool = False) -> int:
     return 0
 
 
+def _rebuild_dependent_current(reloaded_tables: set[str]) -> bool:
+    """Refresh the `_current` relations invalidated by this run. True on success.
+
+    A staging reload replaces the table outright, which leaves every
+    relation derived from it holding the previous drop's rows. The
+    filer-financial ones are read directly by the Python client, the
+    frontend, and the canonical identity builds, so they have to be
+    correct the moment a refresh finishes — rebuilding them anywhere
+    later means those consumers serve the old drop until that step runs
+    (issue #34).
+
+    Only the two basic-fields relations, and only the ones whose source
+    actually reloaded. The grants `_current` relations are deliberately
+    left alone: nothing reads them but the matching pipeline, which
+    rebuilds them at the start of its own run, and they cost 10-30 min
+    each — rebuilding them here would turn a routine refresh into a
+    much longer job to no one's benefit.
+
+    A failure here does NOT invalidate the ingest: the staging data is
+    loaded and its run row stays 'success'. It's loud, and it sets a
+    non-zero exit so the caller notices, but the fix is to rerun the
+    rebuild, not the refresh.
+    """
+    from givingtuesday_datamart._internal.db import get_session
+    from givingtuesday_datamart.current_grants import (
+        build_basic_fields_current,
+        stale_basic_fields_current,
+    )
+    from givingtuesday_datamart.ingestion import datamart_config
+
+    wanted = sorted(
+        f"{table}_current"
+        for table in reloaded_tables
+        if table in ("basic_fields", "basic_fields_pf")
+    )
+    if not wanted:
+        return True
+
+    logger.info("Rebuilding filing-version dedup relations: %s", ", ".join(wanted))
+    try:
+        with get_session(config=datamart_config()) as session:
+            counts = build_basic_fields_current(session.connection(), only=wanted)
+    except Exception:
+        logger.exception(
+            "Staging reloaded successfully, but rebuilding %s FAILED. The "
+            "staging tables are correct; %s still hold the previous drop's "
+            "rows, so the client, the frontend and the canonical identity "
+            "builds will read stale data until this is rerun: "
+            "python -m givingtuesday_datamart.current_grants",
+            ", ".join(wanted),
+            ", ".join(wanted),
+        )
+        return False
+    for table, count in counts.items():
+        logger.info("public.%s rebuilt: %s rows", table, f"{count:,}")
+    return True
+
+
 def cmd_refresh(source_names: list[str] | None, *, force: bool) -> int:
     # Import here so `status` does not pay for the SQLAlchemy init cost.
     from givingtuesday_datamart.ingestion import ingest_source
@@ -312,6 +370,7 @@ def cmd_refresh(source_names: list[str] | None, *, force: bool) -> int:
 
     exit_code = 0
     summary_rows: list[tuple[str, str, str, str]] = []
+    reloaded_tables: set[str] = set()
     for i, spec in enumerate(specs, start=1):
         resolved = resolve_latest(spec, listing=listing)
         if resolved is None:
@@ -347,6 +406,11 @@ def cmd_refresh(source_names: list[str] | None, *, force: bool) -> int:
         )
         if result.status == "failed":
             exit_code = 1
+        if result.status == "success":
+            reloaded_tables.add(spec.staging_table_name.split(".")[-1])
+
+    if not _rebuild_dependent_current(reloaded_tables):
+        exit_code = 1
 
     headers = ("logical_name", "version_date", "status", "row_count")
     widths = [max(len(row[i]) for row in (*summary_rows, headers)) for i in range(len(headers))]


### PR DESCRIPTION
Follow-up to #38. This commit was pushed to `basic-fields-current` after #38 was already squash-merged, so it never reached main — this is that commit, cherry-picked onto current main. Discussion is in [#38's comment](https://github.com/vibrant-data-labs/givingtuesday-datamart/pull/38#issuecomment-5185744234).

## What main has today

Working and self-consistent, but with the problem the review caught: `_current` relations are snapshots, and #38 rebuilds them inside `build_canonical` — step 4 of the refresh runbook. Between step 2 (refresh) and step 4, the Python client and the frontend still read the previous drop. Canonical isn't the only reader of these relations, just the one whose breakage was visible.

## What this changes

**`sources refresh` rebuilds them**, gated on which source actually reloaded (`irs_990_basic_fields` → `basic_fields_current`, `irs_990pf_basic_fields` → `_pf_current`), once at the end of the run. The site is correct the moment refresh finishes.

**Only the two basic-fields relations.** `grants_to_domestic_organizations_current` and `privategrants_current` are read by nothing but `grant_matching`, which rebuilds them at the start of its own run — so refresh pays ~11.5 min rather than ~45.

**Failure semantics**: a rebuild failure leaves the ingest run `'success'` (the staging data is loaded and correct) but logs loudly with the rerun command and sets a non-zero exit.

**`build_canonical` guards instead of rebuilding.** It compares `_ingest_run_id` between each relation and its staging table, rebuilding only on mismatch — two scalar reads on the normal path instead of 11.5 min of duplicated work, while still refusing to build identity from a stale snapshot if staging was loaded some other way.

## Verification

Both detection branches fire, not just the quiet path:

```
missing-table branch: exists=False -> flagged stale: True
mismatch branch (bf vs bf_pf, genuinely different ingest runs): detects difference = True
real pair (basic_fields vs basic_fields_current): run ids match = True
guard against live DB: stale = NONE
gating: no relevant sources -> no rebuild;  grants-only reload -> no rebuild
only= filter: selects exactly the requested relation
```

Re-verified after the cherry-pick onto main: imports clean, guard returns NONE against the live DB.

Known and accepted (your call, recorded here so it isn't rediscovered): `_build_one` does DROP+CTAS in one transaction, so readers block for the 5–7 min rebuild. Acceptable given refresh cadence, and better than the status quo where staging commits its DROP+CREATE before streaming rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
